### PR TITLE
Being composable from other generators

### DIFF
--- a/generators/newmodel/index.js
+++ b/generators/newmodel/index.js
@@ -61,7 +61,7 @@ module.exports = class extends Generator {
         ];
 
         return this.prompt(aPrompt).then((answers) => {
-            this.options.oneTimeConfig = this.config.getAll();
+            this.options.oneTimeConfig = Object.assign({}, this.config.getAll(), this.options);
             this.options.oneTimeConfig.modelName = answers.modelName;
             this.options.oneTimeConfig.modelType = answers.modelType;
             this.options.oneTimeConfig.bindingMode = answers.bindingMode;
@@ -86,12 +86,12 @@ module.exports = class extends Generator {
             const sourceSettings =
                 this.options.oneTimeConfig.modelType === "OData v2"
                     ? {
-                          localUri: "localService/" + this.options.oneTimeConfig.url + "/metadata.xml"
-                      }
+                        localUri: "localService/" + this.options.oneTimeConfig.url + "/metadata.xml"
+                    }
                     : {
-                          localUri: "localService/" + this.options.oneTimeConfig.url + "/metadata.xml",
-                          odataVersion: "4.0"
-                      };
+                        localUri: "localService/" + this.options.oneTimeConfig.url + "/metadata.xml",
+                        odataVersion: "4.0"
+                    };
             const modelType =
                 this.options.oneTimeConfig.modelType === "OData v2"
                     ? "sap.ui.model.odata.v2.ODataModel"
@@ -99,22 +99,22 @@ module.exports = class extends Generator {
             const modelSettings =
                 this.options.oneTimeConfig.modelType === "OData v2"
                     ? {
-                          defaultOperationMode: "Server",
-                          defaultBindingMode: this.options.oneTimeConfig.bindingMode,
-                          defaultCountMode: this.options.oneTimeConfig.countMode,
-                          preload: true
-                      }
+                        defaultOperationMode: "Server",
+                        defaultBindingMode: this.options.oneTimeConfig.bindingMode,
+                        defaultCountMode: this.options.oneTimeConfig.countMode,
+                        preload: true
+                    }
                     : {
-                          synchronizationMode: "None",
-                          operationMode: "Server",
-                          autoExpandSelect: true,
-                          earlyRequests: true,
-                          groupProperties: {
-                              default: {
-                                  submit: "Auto"
-                              }
-                          }
-                      };
+                        synchronizationMode: "None",
+                        operationMode: "Server",
+                        autoExpandSelect: true,
+                        earlyRequests: true,
+                        groupProperties: {
+                            default: {
+                                submit: "Auto"
+                            }
+                        }
+                    };
 
             override = {
                 ["sap.app"]: {

--- a/generators/newmodel/index.js
+++ b/generators/newmodel/index.js
@@ -12,7 +12,7 @@ module.exports = class extends Generator {
                 name: "modulename",
                 message: "To which module do you want to add a model?",
                 choices: modules || [],
-                when: modules && modules.length > 1
+                when: modules ? modules.length > 1 : false
             },
             {
                 type: "input",
@@ -65,7 +65,7 @@ module.exports = class extends Generator {
             this.options.oneTimeConfig.modelName = answers.modelName;
             this.options.oneTimeConfig.modelType = answers.modelType;
             this.options.oneTimeConfig.bindingMode = answers.bindingMode;
-            this.options.oneTimeConfig.modulename = answers.modulename || modules[0];
+            this.options.oneTimeConfig.modulename = answers.modulename || modules ? modules[0] : this.options.modulename;
 
             if (answers.modelType.includes("OData")) {
                 this.options.oneTimeConfig.url = answers.url;

--- a/generators/newview/index.js
+++ b/generators/newview/index.js
@@ -7,7 +7,7 @@ module.exports = class extends Generator {
     prompting() {
         if (this.options.isSubgeneratorCall) {
             this.destinationRoot(this.options.cwd);
-            this.options.oneTimeConfig = this.config.getAll();
+            this.options.oneTimeConfig = Object.assign({}, this.config.getAll(), this.options);
             this.options.oneTimeConfig.modulename = this.options.modulename;
             this.options.oneTimeConfig.viewname = this.options.viewname;
 
@@ -157,8 +157,8 @@ module.exports = class extends Generator {
         var sOrigin = this.templatePath(sViewFileName);
         var sTarget = this.destinationPath(
             sModuleName +
-                "/" +
-                sViewFileName.replace(/\$ViewEnding/, sViewType.toLowerCase()).replace(/\$ViewName/, sViewName)
+            "/" +
+            sViewFileName.replace(/\$ViewEnding/, sViewType.toLowerCase()).replace(/\$ViewName/, sViewName)
         );
         this.fs.copyTpl(sOrigin, sTarget, this.options.oneTimeConfig);
 
@@ -166,10 +166,10 @@ module.exports = class extends Generator {
             sOrigin = this.templatePath(sControllerFileName);
             sTarget = this.destinationPath(
                 sModuleName +
-                    "/" +
-                    sControllerFileName
-                        .replace(/\$ViewEnding/, sViewType.toLowerCase())
-                        .replace(/\$ViewName/, sViewName)
+                "/" +
+                sControllerFileName
+                    .replace(/\$ViewEnding/, sViewType.toLowerCase())
+                    .replace(/\$ViewName/, sViewName)
             );
             this.fs.copyTpl(sOrigin, sTarget, this.options.oneTimeConfig);
         }

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -19,6 +19,10 @@ module.exports = class extends Generator {
             ]).then((answers) => {
                 this.destinationRoot(this.options.cwd);
                 this.options.oneTimeConfig = Object.assign({}, this.config.getAll(), this.options);
+                if (this.options.namespaceInput) {
+                    this.options.oneTimeConfig.namespace = this.options.namespaceInput;
+                }
+                
                 this.options.oneTimeConfig.modulename = this.options.modulename;
                 this.options.oneTimeConfig.tilename = answers.tilename;
                 this.options.oneTimeConfig.viewname = "MainView";

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -18,7 +18,7 @@ module.exports = class extends Generator {
                 }
             ]).then((answers) => {
                 this.destinationRoot(this.options.cwd);
-                this.options.oneTimeConfig = this.config.getAll();
+                this.options.oneTimeConfig = Object.assign({}, this.config.getAll(), this.options);
                 this.options.oneTimeConfig.modulename = this.options.modulename;
                 this.options.oneTimeConfig.tilename = answers.tilename;
                 this.options.oneTimeConfig.viewname = "MainView";


### PR DESCRIPTION
Fix Issue #5 Being composable from other generators:

Subgenerators newwebapp, newmodel and newview are now using options in case there are no attributes in the config (which is scoped by the generator and could not be set via an external generater).