### PR TITLE
Being composable from other generators. 2nd Try

### DIFF
--- a/generators/additionalmodules/index.js
+++ b/generators/additionalmodules/index.js
@@ -37,7 +37,7 @@ module.exports = class extends Generator {
 
             const welcomeRoute = platformIsAppRouter
                 ? "uimodule/index.html"
-                : (oConfig.namespace + oConfig.projectname + "/").replace(/\./g, "");
+                : (oConfig.namespaceUI5 + oConfig.projectname + "/").replace(/\./g, "");
 
             await fileaccess.manipulateJSON.call(this, "/approuter/xs-app.json", {
                 welcomeFile: welcomeRoute,

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -29,7 +29,7 @@ module.exports = class extends Generator {
             },
             {
                 type: "input",
-                name: "namespace",
+                name: "namespaceUI5",
                 message: "Which namespace do you want to use?",
                 validate: (s) => {
                     if (/^[a-zA-Z0-9_\.]*$/g.test(s)) {
@@ -88,10 +88,10 @@ module.exports = class extends Generator {
             }
         ]).then((answers) => {
             if (answers.newdir) {
-                this.destinationRoot(`${answers.namespace}.${answers.projectname}`);
+                this.destinationRoot(`${answers.namespaceUI5}.${answers.projectname}`);
             }
             this.config.set(answers);
-            this.config.set("namespaceURI", answers.namespace.split(".").join("/"));
+            this.config.set("namespaceURI", answers.namespaceUI5.split(".").join("/"));
         });
     }
 

--- a/generators/newcontrol/index.js
+++ b/generators/newcontrol/index.js
@@ -54,7 +54,7 @@ module.exports = class extends Generator {
                 },
                 {
                     type: "input",
-                    name: "namespace",
+                    name: "namespaceUI5",
                     message: "Please enter the namespace you use currently",
                     validate: (s) => {
                         if (/^[a-zA-Z0-9_\.]*$/g.test(s)) {
@@ -73,14 +73,14 @@ module.exports = class extends Generator {
             this.options.oneTimeConfig.modulename = answers.modulename || modules[0];
 
             this.options.oneTimeConfig.appId =
-                this.options.oneTimeConfig.namespace +
+                this.options.oneTimeConfig.namespaceUI5 +
                 "." +
                 (this.options.modulename === "uimodule"
                     ? this.options.oneTimeConfig.projectname
                     : this.options.modulename);
             if (answers.projectname) {
                 this.options.oneTimeConfig.projectname = answers.projectname;
-                this.options.oneTimeConfig.namespace = answers.namespace;
+                this.options.oneTimeConfig.namespaceUI5 = answers.namespaceUI5;
             }
         });
     }

--- a/generators/newmodel/index.js
+++ b/generators/newmodel/index.js
@@ -62,6 +62,7 @@ module.exports = class extends Generator {
 
         return this.prompt(aPrompt).then((answers) => {
             this.options.oneTimeConfig = this.config.getAll();
+            this.options.oneTimeConfig = Object.assign({}, this.config.getAll(), this.options);
             this.options.oneTimeConfig.modelName = answers.modelName;
             this.options.oneTimeConfig.modelType = answers.modelType;
             this.options.oneTimeConfig.bindingMode = answers.bindingMode;

--- a/generators/newopa5journey/index.js
+++ b/generators/newopa5journey/index.js
@@ -11,7 +11,7 @@ module.exports = class extends Generator {
 
         if (this.options.isSubgeneratorCall) {
             this.options.oneTimeConfig.projectname = this.options.projectname;
-            this.options.oneTimeConfig.namespaceInput = this.options.namespaceInput;
+            this.options.oneTimeConfig.namespaceUI5Input = this.options.namespaceUI5Input;
             this.options.oneTimeConfig.modulename = this.options.modulename;
 
             this.options.oneTimeConfig.journey = "Main";
@@ -44,7 +44,7 @@ module.exports = class extends Generator {
                     },
                     {
                         type: "input",
-                        name: "namespaceInput",
+                        name: "namespaceUI5Input",
                         message: "Please enter the namespace you use currently",
                         validate: (s) => {
                             if (/^[a-zA-Z0-9_\.]*$/g.test(s)) {
@@ -83,8 +83,8 @@ module.exports = class extends Generator {
                     this.options.oneTimeConfig[key] = answers[key];
                 }
 
-                this.options.oneTimeConfig.namespaceInput =
-                    this.options.oneTimeConfig.namespaceInput || this.options.oneTimeConfig.namespace;
+                this.options.oneTimeConfig.namespaceUI5Input =
+                    this.options.oneTimeConfig.namespaceUI5Input || this.options.oneTimeConfig.namespaceUI5;
                 this.options.oneTimeConfig.journey =
                     this.options.oneTimeConfig.journey.charAt(0).toUpperCase() +
                     this.options.oneTimeConfig.journey.substr(1);

--- a/generators/newopa5po/index.js
+++ b/generators/newopa5po/index.js
@@ -11,7 +11,7 @@ module.exports = class extends Generator {
 
         if (this.options.isSubgeneratorCall) {
             this.options.oneTimeConfig.projectname = this.options.projectname;
-            this.options.oneTimeConfig.namespaceInput = this.options.namespaceInput;
+            this.options.oneTimeConfig.namespaceUI5Input = this.options.namespaceUI5Input;
             this.options.oneTimeConfig.modulename = this.options.modulename;
 
             this.options.oneTimeConfig.assertion = "iShouldSeeTheTitle";
@@ -43,7 +43,7 @@ module.exports = class extends Generator {
                     },
                     {
                         type: "input",
-                        name: "namespaceInput",
+                        name: "namespaceUI5Input",
                         message: "Please enter the namespace you use currently",
                         validate: (s) => {
                             if (/^[a-zA-Z0-9_\.]*$/g.test(s)) {
@@ -96,13 +96,13 @@ module.exports = class extends Generator {
                     !this.options.oneTimeConfig.modulename || this.options.oneTimeConfig.modulename === "uimodule"
                         ? this.options.oneTimeConfig.projectname
                         : this.options.oneTimeConfig.modulename;
-                this.options.oneTimeConfig.namespaceInput =
-                    this.options.oneTimeConfig.namespaceInput || this.options.oneTimeConfig.namespace;
+                this.options.oneTimeConfig.namespaceUI5Input =
+                    this.options.oneTimeConfig.namespaceUI5Input || this.options.oneTimeConfig.namespaceUI5;
                 this.options.oneTimeConfig.poName =
                     this.options.oneTimeConfig.poName.charAt(0).toUpperCase() +
                     this.options.oneTimeConfig.poName.substr(1);
                 this.options.oneTimeConfig.appId =
-                    this.options.oneTimeConfig.appId || this.options.oneTimeConfig.namespaceInput + "." + appName;
+                    this.options.oneTimeConfig.appId || this.options.oneTimeConfig.namespaceUI5Input + "." + appName;
 
                 const pos = this.config.get("opa5pos") || [];
                 pos.push(this.options.oneTimeConfig.poName);

--- a/generators/newview/index.js
+++ b/generators/newview/index.js
@@ -12,7 +12,7 @@ module.exports = class extends Generator {
             this.options.oneTimeConfig.viewname = this.options.viewname;
 
             this.options.oneTimeConfig.appId =
-                this.options.oneTimeConfig.namespace +
+                this.options.oneTimeConfig.namespaceUI5 +
                 "." +
                 (this.options.modulename === "uimodule"
                     ? this.options.oneTimeConfig.projectname
@@ -76,7 +76,7 @@ module.exports = class extends Generator {
                 },
                 {
                     type: "input",
-                    name: "namespace",
+                    name: "namespaceUI5",
                     message: "Please enter the namespace you use currently",
                     validate: (s) => {
                         if (/^[a-zA-Z0-9_\.]*$/g.test(s)) {
@@ -111,12 +111,12 @@ module.exports = class extends Generator {
 
             if (answers.projectname) {
                 this.options.oneTimeConfig.projectname = answers.projectname;
-                this.options.oneTimeConfig.namespace = answers.namespace;
+                this.options.oneTimeConfig.namespaceUI5 = answers.namespaceUI5;
                 this.options.oneTimeConfig.viewtype = answers.viewtype;
             }
 
             this.options.oneTimeConfig.appId =
-                this.options.oneTimeConfig.namespace +
+                this.options.oneTimeConfig.namespaceUI5 +
                 "." +
                 (this.options.oneTimeConfig.modulename === "uimodule"
                     ? this.options.oneTimeConfig.projectname

--- a/generators/newview/index.js
+++ b/generators/newview/index.js
@@ -7,7 +7,7 @@ module.exports = class extends Generator {
     prompting() {
         if (this.options.isSubgeneratorCall) {
             this.destinationRoot(this.options.cwd);
-            this.options.oneTimeConfig = this.config.getAll();
+            this.options.oneTimeConfig = Object.assign({}, this.config.getAll(), this.options);
             this.options.oneTimeConfig.modulename = this.options.modulename;
             this.options.oneTimeConfig.viewname = this.options.viewname;
 

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -24,7 +24,7 @@ module.exports = class extends Generator {
                 this.options.oneTimeConfig.viewname = "MainView";
 
                 this.options.oneTimeConfig.appId =
-                    this.options.oneTimeConfig.namespace +
+                    this.options.oneTimeConfig.namespaceUI5 +
                     "." +
                     (this.options.modulename === "uimodule"
                         ? this.options.oneTimeConfig.projectname
@@ -40,7 +40,7 @@ module.exports = class extends Generator {
                     require.resolve("../opa5"),
                     Object.assign({}, this.options.oneTimeConfig, {
                         isSubgeneratorCall: true,
-                        namespaceInput: this.options.oneTimeConfig.namespace
+                        namespaceUI5Input: this.options.oneTimeConfig.namespaceUI5
                     })
                 );
             });
@@ -84,7 +84,7 @@ module.exports = class extends Generator {
                 },
                 {
                     type: "input",
-                    name: "namespace",
+                    name: "namespaceUI5",
                     message: "Please enter the namespace you use currently",
                     validate: (s) => {
                         if (/^[a-zA-Z0-9_\.]*$/g.test(s)) {
@@ -112,13 +112,13 @@ module.exports = class extends Generator {
 
             if (answers.projectname) {
                 this.options.oneTimeConfig.projectname = answers.projectname;
-                this.options.oneTimeConfig.namespace = answers.namespace;
-                this.options.oneTimeConfig.namespaceURI = answers.namespace.split(".").join("/");
+                this.options.oneTimeConfig.namespaceUI5 = answers.namespaceUI5;
+                this.options.oneTimeConfig.namespaceURI = answers.namespaceUI5.split(".").join("/");
                 this.options.oneTimeConfig.viewtype = answers.viewtype;
             }
 
             this.options.oneTimeConfig.appId =
-                this.options.oneTimeConfig.namespace +
+                this.options.oneTimeConfig.namespaceUI5 +
                 "." +
                 (answers.modulename === "uimodule" ? this.options.oneTimeConfig.projectname : answers.modulename);
             this.options.oneTimeConfig.appURI =
@@ -130,7 +130,7 @@ module.exports = class extends Generator {
                 require.resolve("../opa5"),
                 Object.assign({}, this.options.oneTimeConfig, {
                     isSubgeneratorCall: true,
-                    namespaceInput: this.options.oneTimeConfig.namespace
+                    namespaceUI5Input: this.options.oneTimeConfig.namespaceUI5
                 })
             );
         });

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -18,7 +18,10 @@ module.exports = class extends Generator {
                 }
             ]).then((answers) => {
                 this.destinationRoot(this.options.cwd);
-                this.options.oneTimeConfig = this.config.getAll();
+                this.options.oneTimeConfig = Object.assign({}, this.config.getAll(), this.options);
+                if (this.options.namespaceUI5Input) {
+                    this.options.oneTimeConfig.namespaceUI5 = this.options.namespaceUI5Input;
+                }
                 this.options.oneTimeConfig.modulename = this.options.modulename;
                 this.options.oneTimeConfig.tilename = answers.tilename;
                 this.options.oneTimeConfig.viewname = "MainView";

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -19,9 +19,6 @@ module.exports = class extends Generator {
             ]).then((answers) => {
                 this.destinationRoot(this.options.cwd);
                 this.options.oneTimeConfig = Object.assign({}, this.config.getAll(), this.options);
-                if (this.options.namespaceUI5Input) {
-                    this.options.oneTimeConfig.namespaceUI5 = this.options.namespaceUI5Input;
-                }
                 this.options.oneTimeConfig.modulename = this.options.modulename;
                 this.options.oneTimeConfig.tilename = answers.tilename;
                 this.options.oneTimeConfig.viewname = "MainView";

--- a/generators/opa5/index.js
+++ b/generators/opa5/index.js
@@ -7,8 +7,8 @@ module.exports = class extends Generator {
 
     prompting() {
         let aPrompt = [];
-        this.options.oneTimeConfig = this.config.getAll();
-
+        this.options.oneTimeConfig = Object.assign({}, this.config.getAll(), this.options);
+                
         if (this.options.isSubgeneratorCall) {
             this.options.oneTimeConfig.projectname = this.options.projectname;
             this.options.oneTimeConfig.namespaceUI5Input = this.options.namespaceUI5Input;

--- a/generators/opa5/index.js
+++ b/generators/opa5/index.js
@@ -11,15 +11,15 @@ module.exports = class extends Generator {
 
         if (this.options.isSubgeneratorCall) {
             this.options.oneTimeConfig.projectname = this.options.projectname;
-            this.options.oneTimeConfig.namespaceInput = this.options.namespaceInput;
+            this.options.oneTimeConfig.namespaceUI5Input = this.options.namespaceUI5Input;
             this.options.oneTimeConfig.modulename = this.options.modulename;
 
             var appName =
                 !this.options.oneTimeConfig.modulename || this.options.modulename === "uimodule"
                     ? this.options.projectname
                     : this.options.modulename;
-            this.options.oneTimeConfig.namespaceURI = this.options.namespaceInput.split(".").join("/");
-            this.options.oneTimeConfig.appId = this.options.namespaceInput + "." + appName;
+            this.options.oneTimeConfig.namespaceURI = this.options.namespaceUI5Input.split(".").join("/");
+            this.options.oneTimeConfig.appId = this.options.namespaceUI5Input + "." + appName;
             this.options.oneTimeConfig.appURI = this.options.namespaceURI + "/" + appName;
             this.options.oneTimeConfig.title = appName;
 
@@ -44,7 +44,7 @@ module.exports = class extends Generator {
                     },
                     {
                         type: "input",
-                        name: "namespaceInput",
+                        name: "namespaceUI5Input",
                         message: "Please enter the namespace you use currently",
                         validate: (s) => {
                             if (/^[a-zA-Z0-9_\.]*$/g.test(s)) {
@@ -93,10 +93,10 @@ module.exports = class extends Generator {
                 !this.options.oneTimeConfig.modulename || this.options.oneTimeConfig.modulename === "uimodule"
                     ? this.options.oneTimeConfig.projectname
                     : this.options.oneTimeConfig.modulename;
-            this.options.oneTimeConfig.namespaceInput =
-                this.options.oneTimeConfig.namespaceInput || this.options.oneTimeConfig.namespace;
-            this.options.oneTimeConfig.namespaceURI = this.options.oneTimeConfig.namespaceInput.split(".").join("/");
-            this.options.oneTimeConfig.appId = this.options.oneTimeConfig.namespaceInput + "." + appName;
+            this.options.oneTimeConfig.namespaceUI5Input =
+                this.options.oneTimeConfig.namespaceUI5Input || this.options.oneTimeConfig.namespaceUI5;
+            this.options.oneTimeConfig.namespaceURI = this.options.oneTimeConfig.namespaceUI5Input.split(".").join("/");
+            this.options.oneTimeConfig.appId = this.options.oneTimeConfig.namespaceUI5Input + "." + appName;
             this.options.oneTimeConfig.appURI = this.options.oneTimeConfig.namespaceURI + "/" + appName;
             this.options.oneTimeConfig.title = appName;
         });


### PR DESCRIPTION
Fix Issue #5 Being composable from other generators:

Subgenerators newwebapp, newmodel and newview are now using options in case there are no attributes in the config (which is scoped by the generator and could not be set via an external generator). Also renamed option "namespace" to "namespaceUI5", because the option namespace is already used by the yeoman framework.