### PR TITLE
fix: several issues

### DIFF
--- a/generators/app/templates/_.eslintignore
+++ b/generators/app/templates/_.eslintignore
@@ -2,3 +2,4 @@ templates/
 deployer/resources/
 node_modules/
 approuter/webapp/
+uimodule/webapp/utils/locate-reuse-libs.js

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -198,6 +198,8 @@ module.exports = class extends Generator {
                     );
                     this.log(`  ${chalk.blueBright("created")} ${relativeFilePath}`);
                 });
+
+                // relay chosen UI5 lib location -> @sap-ux/fiori-freestyle-writer's index.html
                 const index = { html: this.destinationPath(sModuleName, "webapp/index.html") };
                 let _ui5libs = "";
                 switch (this.options.oneTimeConfig.ui5libs) {
@@ -217,8 +219,11 @@ module.exports = class extends Generator {
                     index.html,
                     (await fs.readFile(index.html)).toString().replace(/src=".*"/g, `src="${_ui5libs}"`)
                 );
+                this.log(`  ${chalk.blueBright("\u26A0 \uFE0F patched @sap-ux's")} index.html with ${this.options.oneTimeConfig.ui5libs}`);
 
-                // fix up test/flpSandbox.html - sap.ushell is only available in sapui5
+
+                // fix up @sap-ux/fiori-freestyle-writer's test/flpSandbox.html -
+                // sap.ushell is only available in sapui5
                 // bootstrap only from there, no matter the used framework choice..
                 const flpSandbox = { html: this.destinationPath(sModuleName, "webapp/test/flpSandbox.html") };
                 await fs.writeFile(
@@ -229,6 +234,7 @@ module.exports = class extends Generator {
                             return match.replace("..", "https://sapui5.hana.ondemand.com");
                         })
                 );
+                this.log(`  ${chalk.blueBright("\u26A0 \uFE0F patched @sap-ux's")} flpSandbox.html to boostrap only SAPUI5 (sap.ushell!)`);
 
 
                 // make @sap-ux/fiori-freestyle-writer's MainView.controller

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -239,13 +239,16 @@ module.exports = class extends Generator {
                 this.log(chalk.red(error.message || JSON.stringify(error)));
             }
 
-            // handle easy-ui5 specific ui5.yaml
-            // and put base controller in place
-            [["ui5.yaml"], ["webapp", "controller", "BaseController.js"]].forEach((file) => {
-                const src = this.templatePath("uimodule", ...file);
-                const dest = this.destinationPath(sModuleName, ...file);
-                this.fs.copyTpl(src, dest, this.options.oneTimeConfig);
-            });
+            // handle easy-ui5 specific ui5.yaml, put
+            // put base controller in place
+            // and provide model/formatter.js
+            [["ui5.yaml"], ["webapp", "controller", "BaseController.js"], ["webapp", "model", "formatter.js"]].forEach(
+                (file) => {
+                    const src = this.templatePath("uimodule", ...file);
+                    const dest = this.destinationPath(sModuleName, ...file);
+                    this.fs.copyTpl(src, dest, this.options.oneTimeConfig);
+                }
+            );
 
             // special handling of files specific to deployment scenarios
             // > flpSandbox.html is created by @sap-ux/fiori-freestyle-writer in test/

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -187,7 +187,7 @@ module.exports = class extends Generator {
                 ].map(async (file) => {
                     await fs.unlink(this.destinationPath(sModuleName, file));
                 });
-                
+
                 // relay chosen UI5 lib location -> index.html
                 const index = { html: this.destinationPath(sModuleName, "webapp/index.html") };
                 let _ui5libs = "";
@@ -207,6 +207,18 @@ module.exports = class extends Generator {
                 await fs.writeFile(
                     index.html,
                     (await fs.readFile(index.html)).toString().replace(/src=".*"/g, `src="${_ui5libs}"`)
+                );
+
+                // fix up test/flpSandbox.html - sap.ushell is only available in sapui5
+                // bootstrap only from there, no matter the used framework choice..
+                const flpSandbox = { html: this.destinationPath(sModuleName, "webapp/test/flpSandbox.html") };
+                await fs.writeFile(
+                    flpSandbox.html,
+                    (await fs.readFile(flpSandbox.html))
+                        .toString()
+                        .replace(/src="(..)\/(test-)?resources/g, (match) => {
+                            return match.replace("..", "https://sapui5.hana.ondemand.com");
+                        })
                 );
 
                 this.log(

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -187,9 +187,7 @@ module.exports = class extends Generator {
                 ].map(async (file) => {
                     await fs.unlink(this.destinationPath(sModuleName, file));
                 });
-                // "webapp/utils" only holds a single file
-                await fs.rm(this.destinationPath(sModuleName, "webapp/utils"), { force: true, recursive: true });
-
+                
                 // relay chosen UI5 lib location -> index.html
                 const index = { html: this.destinationPath(sModuleName, "webapp/index.html") };
                 let _ui5libs = "";

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -230,9 +230,19 @@ module.exports = class extends Generator {
                         })
                 );
 
-                this.log(
-                    `used ${chalk.blueBright("@sap-ux/fiori-freestyle-writer")} to generate freestyle app skeleton :)`
+
+                // make @sap-ux/fiori-freestyle-writer's MainView.controller
+                // aware of easy-ui5's base controller
+                const MainViewController = {
+                    js: this.destinationPath(sModuleName, "webapp/controller/MainView.controller.js")
+                };
+                await fs.writeFile(
+                    MainViewController.js,
+                    (await fs.readFile(MainViewController.js))
+                        .toString()
+                        .replace(/sap\/ui\/core\/mvc\/Controller/g, "./BaseController")
                 );
+                this.log(`  ${chalk.blueBright("\u26A0 \uFE0F patched @sap-ux's")} MainViewController.js to use ./BaseController`);
                 
             } catch (error) {
                 this.log("Urgh. Something went wrong. Lookie:");

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -233,11 +233,7 @@ module.exports = class extends Generator {
             });
 
             // special handling of files specific to deployment scenarios
-            if (this.options.oneTimeConfig.platform !== "SAP Launchpad service") {
-                const flpSandboxSrc = this.templatePath("uimodule", "webapp", "flpSandbox.html");
-                const flpSandboxDest = this.destinationPath(sModuleName, "webapp", "flpSandbox.html");
-                this.fs.copyTpl(flpSandboxSrc, flpSandboxDest, this.options.oneTimeConfig);
-            }
+            // > flpSandbox.html is created by @sap-ux/fiori-freestyle-writer in test/
             if (
                 this.options.oneTimeConfig.platform === "SAP Launchpad service" ||
                 this.options.oneTimeConfig.platform === "SAP HTML5 Application Repository service for SAP BTP"

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -188,7 +188,16 @@ module.exports = class extends Generator {
                     await fs.unlink(this.destinationPath(sModuleName, file));
                 });
 
-                // relay chosen UI5 lib location -> index.html
+                this.log(
+                    `used ${chalk.blueBright("@sap-ux/fiori-freestyle-writer")} to generate freestyle app skeleton :)`
+                );
+                dirTree(this.destinationPath(sModuleName), null, (item) => {
+                    const relativeFilePath = item.path.replace(
+                        `${this.destinationPath(sModuleName)}${path.sep}`,
+                        `${sModuleName}${path.sep}`
+                    );
+                    this.log(`  ${chalk.blueBright("created")} ${relativeFilePath}`);
+                });
                 const index = { html: this.destinationPath(sModuleName, "webapp/index.html") };
                 let _ui5libs = "";
                 switch (this.options.oneTimeConfig.ui5libs) {
@@ -224,13 +233,7 @@ module.exports = class extends Generator {
                 this.log(
                     `used ${chalk.blueBright("@sap-ux/fiori-freestyle-writer")} to generate freestyle app skeleton :)`
                 );
-                dirTree(this.destinationPath(sModuleName), null, (item) => {
-                    const relativeFilePath = item.path.replace(
-                        `${this.destinationPath(sModuleName)}${path.sep}`,
-                        `${sModuleName}${path.sep}`
-                    );
-                    this.log(`  ${chalk.blueBright("created")} ${relativeFilePath}`);
-                });
+                
             } catch (error) {
                 this.log("Urgh. Something went wrong. Lookie:");
                 this.log(chalk.red(error.message || JSON.stringify(error)));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-template-ui5-project",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "(Sub-)generator for a UI5 project",
   "scripts": {
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "generators"
   ],
   "dependencies": {
-    "@sap-ux/fiori-freestyle-writer": "^0.10.0",
+    "@sap-ux/fiori-freestyle-writer": "^0.10.10",
     "chalk": "^4.1.2",
     "directory-tree": "^3.0.0",
     "glob": "^7.2.0",

--- a/test/basic.js
+++ b/test/basic.js
@@ -22,14 +22,18 @@ function createTest(oPrompt) {
             ]);
         });
 
-        // @sap-ux/fiori-freestyle-writer is used for scaffolding an XML-view based webapp
-        // but doesn't have a base controller in place
+        // regular easy-ui5 is used for scaffolding
         if (oPrompt.viewtype !== "XML") {
             it("should reference the base controller", function () {
                 return assert.fileContent(
                     "uimodule/webapp/controller/MainView.controller.js",
                     "controller/BaseController"
                 );
+            });
+        } else {
+            // @sap-ux/fiori-freestyle-writer is used for scaffolding an XML-view based webapp
+            it("should reference the base controller via file path", function () {
+                return assert.fileContent("uimodule/webapp/controller/MainView.controller.js", "./BaseController");
             });
         }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -33,6 +33,15 @@ function createTest(oPrompt) {
             });
         }
 
+        if (oPrompt.viewtype === "XML") {
+            it.only("should make sure the flpSandbox.html is in test/ and bootstraps SAPUI5", function () {
+                return (
+                    assert.file("uimodule/webapp/test/flpSandbox.html") &&
+                    assert.fileContent("uimodule/webapp/test/flpSandbox.html", "https://sapui5.hana.ondemand.com")
+                );
+            });
+        }
+
         if (
             !!oPrompt.platform &&
             oPrompt.platform !== "Static webserver" &&

--- a/test/basic.js
+++ b/test/basic.js
@@ -30,19 +30,19 @@ function createTest(oPrompt) {
                     "controller/BaseController"
                 );
             });
-        } else {
-            // @sap-ux/fiori-freestyle-writer is used for scaffolding an XML-view based webapp
-            it("should reference the base controller via file path", function () {
-                return assert.fileContent("uimodule/webapp/controller/MainView.controller.js", "./BaseController");
-            });
         }
 
-        if (oPrompt.viewtype === "XML") {
+        // @sap-ux/fiori-freestyle-writer is used for scaffolding an XML-view based webapp
+        if (oPrompt.viewtype === "XML" && oPrompt.ui5libs && oPrompt.platform) {
             it.only("should make sure the flpSandbox.html is in test/ and bootstraps SAPUI5", function () {
                 return (
                     assert.file("uimodule/webapp/test/flpSandbox.html") &&
                     assert.fileContent("uimodule/webapp/test/flpSandbox.html", "https://sapui5.hana.ondemand.com")
                 );
+            });
+
+            it("should reference the base controller via file path", function () {
+                return assert.fileContent("uimodule/webapp/controller/MainView.controller.js", "./BaseController");
             });
         }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -34,7 +34,7 @@ function createTest(oPrompt) {
 
         // @sap-ux/fiori-freestyle-writer is used for scaffolding an XML-view based webapp
         if (oPrompt.viewtype === "XML" && oPrompt.ui5libs && oPrompt.platform) {
-            it.only("should make sure the flpSandbox.html is in test/ and bootstraps SAPUI5", function () {
+            it("should make sure the flpSandbox.html is in test/ and bootstraps SAPUI5", function () {
                 return (
                     assert.file("uimodule/webapp/test/flpSandbox.html") &&
                     assert.fileContent("uimodule/webapp/test/flpSandbox.html", "https://sapui5.hana.ondemand.com")


### PR DESCRIPTION
- `test/flpSandbox.html` not working → only bootstrap off of sapui5 cdn due to availability of `sap.ushell` (fixes #19)
- patching `@sap/ux`'s main controller to utilize base controller (fixes #20)
- add `model/formatter.js` back in (also mentioned in #20)

additionally: more verbose log output of 
- what's used via `@sap-ux/fiori-freestyle-writer` 
- what's patched from `@sap-ux/fiori-freestyle-writer` for `easy-ui5`
- what's created by `generator-ui5-project` itself (`easy-ui5`-"standard")

kudos to @lboehm for digging deep!