### PR TITLE
fix: include reuse libs for Launchpad #36

### DIFF
--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -73,7 +73,7 @@ module.exports = class extends Generator {
             {
                 type: "input",
                 name: "tilename",
-                message: "What name should be displayed on the Fiori Launchpad tilee?",
+                message: "What name should be displayed on the Fiori Launchpad tile?",
                 default: "Fiori App",
                 when: this.config.get("platform") === "SAP Launchpad service"
             }

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -155,7 +155,8 @@ module.exports = class extends Generator {
             this.options.oneTimeConfig.ui5libs === "Local resources (SAPUI5)";
         const platformIsAppRouter = this.options.oneTimeConfig.platform.includes("Application Router");
         const platformIsLaunchpad = this.options.oneTimeConfig.platform === "SAP Launchpad service"
-        const netweaver = this.options.oneTimeConfig.platform.includes("SAP NetWeaver");
+        const platformIsHTML5AppRepo = this.options.oneTimeConfig.platform === "SAP HTML5 Application Repository service for SAP BTP"
+        const platformIsNetWeaver = this.options.oneTimeConfig.platform.includes("SAP NetWeaver");
 
         this.sourceRoot(path.join(__dirname, "templates"));
 
@@ -292,7 +293,7 @@ module.exports = class extends Generator {
             // > flpSandbox.html is created by @sap-ux/fiori-freestyle-writer in test/
             if (
                 platformIsLaunchpad ||
-                this.options.oneTimeConfig.platform === "SAP HTML5 Application Repository service for SAP BTP"
+                platformIsHTML5AppRepo
             ) {
                 const xsAppSrc = this.templatePath("uimodule", "webapp", "xs-app.json");
                 const xsAppDest = this.destinationPath(sModuleName, "webapp", "xs-app.json");
@@ -309,12 +310,12 @@ module.exports = class extends Generator {
                 const sTarget = this.destinationPath(file.replace("uimodule", sModuleName).replace(/\/_/, "/"));
 
                 const isUnneededFlpSandbox =
-                    sTarget.includes("flpSandbox") && this.options.oneTimeConfig.platform !== "SAP Launchpad service";
+                    sTarget.includes("flpSandbox") && !platformIsLaunchpad;
                 const isUnneededXsApp =
                     sTarget.includes("xs-app") &&
                     !(
                         platformIsLaunchpad ||
-                        this.options.oneTimeConfig.platform === "SAP HTML5 Application Repository service for SAP BTP"
+                        platformIsHTML5AppRepo
                     );
 
                 if (isUnneededXsApp || isUnneededFlpSandbox) {
@@ -325,7 +326,7 @@ module.exports = class extends Generator {
             });
         }
 
-        if (this.options.oneTimeConfig.platform.includes("Application Router")) {
+        if (platformIsAppRouter) {
             this.log("configuring app router settings...");
             await fileaccess.manipulateJSON.call(this, "/approuter/xs-app.json", {
                 routes: [
@@ -340,7 +341,7 @@ module.exports = class extends Generator {
         }
 
         if (
-            this.options.oneTimeConfig.platform === "SAP HTML5 Application Repository service for SAP BTP" ||
+            platformIsHTML5AppRepo ||
             platformIsLaunchpad
         ) {
             if (platformIsLaunchpad) {
@@ -379,7 +380,7 @@ module.exports = class extends Generator {
             }
             if (platformIsAppRouter) {
                 buildCommand += ` --dest approuter/${sModuleName}/webapp`;
-            } else if (!netweaver) {
+            } else if (!platformIsNetWeaver) {
                 buildCommand += ` --dest ${sModuleName}/dist`;
                 buildCommand += " --include-task=generateManifestBundle";
             } else {
@@ -390,7 +391,7 @@ module.exports = class extends Generator {
         });
 
         if (
-            this.options.oneTimeConfig.platform === "SAP HTML5 Application Repository service for SAP BTP" ||
+            platformIsHTML5AppRepo ||
             platformIsLaunchpad
         ) {
             this.log("configuring deployment options...");

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -73,7 +73,7 @@ module.exports = class extends Generator {
             {
                 type: "input",
                 name: "tilename",
-                message: "What name should be displayed on the Fiori Launchpad tile?",
+                message: "What name should be displayed on the Fiori Launchpad tilee?",
                 default: "Fiori App",
                 when: this.config.get("platform") === "SAP Launchpad service"
             }
@@ -154,6 +154,7 @@ module.exports = class extends Generator {
             this.options.oneTimeConfig.ui5libs === "Local resources (OpenUI5)" ||
             this.options.oneTimeConfig.ui5libs === "Local resources (SAPUI5)";
         const platformIsAppRouter = this.options.oneTimeConfig.platform.includes("Application Router");
+        const platformIsLaunchpad = this.options.oneTimeConfig.platform === "SAP Launchpad service"
         const netweaver = this.options.oneTimeConfig.platform.includes("SAP NetWeaver");
 
         this.sourceRoot(path.join(__dirname, "templates"));
@@ -178,7 +179,7 @@ module.exports = class extends Generator {
                     }
                 },
                 appOptions: {
-                    loadReuseLibs: this.options.oneTimeConfig.platform === "SAP Launchpad service"
+                    loadReuseLibs: platformIsLaunchpad
                 }
             };
 
@@ -290,7 +291,7 @@ module.exports = class extends Generator {
             // special handling of files specific to deployment scenarios
             // > flpSandbox.html is created by @sap-ux/fiori-freestyle-writer in test/
             if (
-                this.options.oneTimeConfig.platform === "SAP Launchpad service" ||
+                platformIsLaunchpad ||
                 this.options.oneTimeConfig.platform === "SAP HTML5 Application Repository service for SAP BTP"
             ) {
                 const xsAppSrc = this.templatePath("uimodule", "webapp", "xs-app.json");
@@ -312,7 +313,7 @@ module.exports = class extends Generator {
                 const isUnneededXsApp =
                     sTarget.includes("xs-app") &&
                     !(
-                        this.options.oneTimeConfig.platform === "SAP Launchpad service" ||
+                        platformIsLaunchpad ||
                         this.options.oneTimeConfig.platform === "SAP HTML5 Application Repository service for SAP BTP"
                     );
 
@@ -340,9 +341,9 @@ module.exports = class extends Generator {
 
         if (
             this.options.oneTimeConfig.platform === "SAP HTML5 Application Repository service for SAP BTP" ||
-            this.options.oneTimeConfig.platform === "SAP Launchpad service"
+            platformIsLaunchpad
         ) {
-            if (this.options.oneTimeConfig.platform === "SAP Launchpad service") {
+            if (platformIsLaunchpad) {
                 this.log("configuring Launchpad integration...");
                 await fileaccess.manipulateJSON.call(this, "/" + sModuleName + "/webapp/manifest.json", {
                     ["sap.cloud"]: {
@@ -390,7 +391,7 @@ module.exports = class extends Generator {
 
         if (
             this.options.oneTimeConfig.platform === "SAP HTML5 Application Repository service for SAP BTP" ||
-            this.options.oneTimeConfig.platform === "SAP Launchpad service"
+            platformIsLaunchpad
         ) {
             this.log("configuring deployment options...");
             await fileaccess.writeYAML.call(this, "/mta.yaml", (mta) => {

--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -178,7 +178,7 @@ module.exports = class extends Generator {
                     }
                 },
                 appOptions: {
-                    loadReuseLibs: false
+                    loadReuseLibs: this.options.oneTimeConfig.platform === "SAP Launchpad service"
                 }
             };
 


### PR DESCRIPTION
Looks like the [commit from last week](https://github.com/ui5-community/generator-ui5-project/pull/34/commits/dab1f704fc37b3daa7198b641c0e448c67bcb3b6) didn't do the job 100% (for #35), as we do need the reuse libs for the Fiori Launchpad. This fixes #36.