### PR TITLE
fix(tests): Error: No parser could be inferred for file

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -159,8 +159,7 @@ module.exports = class extends Generator {
                 clearCoverage: "shx rm -rf coverage",
                 karma: "run-s clearCoverage karma-ci",
                 lint: "eslint ./**/webapp/**/*.js && prettier --check ./**/webapp/**/*.{js,xml}",
-                "lint-fix":
-                    "eslint ./**/webapp/**/*.js --fix && prettier --write ./**/webapp/**/*.{js,xml} --ignore-unknown"
+                "lint-fix": "eslint ./**/webapp/**/*.js --fix && prettier --write ./**/webapp/**/*.{js,xml} --no-error-on-unmatched-pattern"
             },
             devDependencies: {
                 shx: "^0.3.3",

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -159,7 +159,7 @@ module.exports = class extends Generator {
                 clearCoverage: "shx rm -rf coverage",
                 karma: "run-s clearCoverage karma-ci",
                 lint: "eslint ./**/webapp/**/*.js && prettier --check ./**/webapp/**/*.{js,xml}",
-                "lint-fix": "eslint ./**/webapp/**/*.js --fix && prettier --write ./**/webapp/**/*.{js,xml} --no-error-on-unmatched-pattern"
+                "lint-fix": "eslint ./**/webapp/**/*.js --fix && prettier --plugin-search-dir=. --write ./**/webapp/**/*.{js,xml} --no-error-on-unmatched-pattern"
             },
             devDependencies: {
                 shx: "^0.3.3",

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -159,7 +159,8 @@ module.exports = class extends Generator {
                 clearCoverage: "shx rm -rf coverage",
                 karma: "run-s clearCoverage karma-ci",
                 lint: "eslint ./**/webapp/**/*.js && prettier --check ./**/webapp/**/*.{js,xml}",
-                "lint-fix": "eslint ./**/webapp/**/*.js --fix && prettier --write ./**/webapp/**/*.{js,xml} --no-error-on-unmatched-pattern"
+                "lint-fix":
+                    "eslint ./**/webapp/**/*.js --fix && prettier --write ./**/webapp/**/*.{js,xml} --ignore-unknown"
             },
             devDependencies: {
                 shx: "^0.3.3",

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -158,7 +158,7 @@ module.exports = class extends Generator {
                 "karma-ci": "karma start karma-ci.conf.js",
                 clearCoverage: "shx rm -rf coverage",
                 karma: "run-s clearCoverage karma-ci",
-                lint: "eslint ./**/webapp/**/*.js && prettier --check ./**/webapp/**/*.{js,xml}",
+                lint: "eslint ./**/webapp/**/*.js && prettier --plugin-search-dir=. --check ./**/webapp/**/*.{js,xml}",
                 "lint-fix": "eslint ./**/webapp/**/*.js --fix && prettier --plugin-search-dir=. --write ./**/webapp/**/*.{js,xml} --no-error-on-unmatched-pattern"
             },
             devDependencies: {


### PR DESCRIPTION
PR was opened because of the error in the actions:
https://github.com/ui5-community/generator-ui5-project/runs/5611992482?check_suite_focus=true

Seems like @nicogeburek tried to fix it with this commit?  https://github.com/ui5-community/generator-ui5-project/commit/cc61307d909f8dc07b8ab5de396192a011eb621e

~~My solution was to add `--ignore-unknown` because of this entry:~~
~~https://github.com/prettier/prettier/blob/24d39a906834cf449304dc684b280a5ca9a0a6d7/website/blog/2020-08-24-2.1.0.md#added---ignore-unknownalias--u-flag-8829-by-fisker~~

Solution was wrong, reverted the old solution.
New solution:

Based on a old prettier issue (https://github.com/prettier/prettier/issues/8056) i found this workaround: https://github.com/withastro/prettier-plugin-astro/issues/97#issuecomment-1013645333
> pass --plugin-search-dir=. to the prettier cli

This solution makes more sense because in the error log is:
`Error:  No parser could be inferred for file: uimodule/webapp/view/MainView.view.xml`

So probably prettier does not find the prettier plugin `@prettier/plugin-xml` to parse xml.
With this solution prettier uses the plugin.