### PR TITLE
fix: add destination content to mta.yaml #49

### DIFF
--- a/helpers/fileaccess.js
+++ b/helpers/fileaccess.js
@@ -1,7 +1,7 @@
 const objectAssignDeep = require("object-assign-deep"),
     yaml = require("yaml");
 
-// overide can be an object or a function that receives the current object
+// override can be an object or a function that receives the current object
 exports.writeJSON = async function (filePath, override) {
     try {
         const fullFilePath = process.cwd() + filePath;
@@ -25,7 +25,7 @@ exports.writeJSON = async function (filePath, override) {
     }
 };
 
-// overide can be an object or a function that receives the current object
+// override can be an object or a function that receives the current object
 exports.writeYAML = async function (filePath, override) {
     try {
         const fullFilePath = process.cwd() + filePath;
@@ -50,7 +50,7 @@ exports.writeYAML = async function (filePath, override) {
     }
 };
 
-// overide can be an object or a function that receives the current object
+// override can be an object or a function that receives the current object
 exports.manipulateJSON = async function (filePath, override) {
     try {
         const fullFilePath = process.cwd() + filePath;
@@ -71,7 +71,7 @@ exports.manipulateJSON = async function (filePath, override) {
     }
 };
 
-// overide can be an object or a function that receives the current object
+// override can be an object or a function that receives the current object
 exports.manipulateYAML = async function (filePath, override) {
     try {
         const fullFilePath = process.cwd() + filePath;


### PR DESCRIPTION
This is aiming to fix #49.
I added the destination content to the `mta.yaml` after it is being created so that the application will be displayed in the HTML5 Application Repository in the SAP BTP Cockpit (after deployment).
Unfortunately I couldn't really figure out where the `mta.yaml` gets created initially. There has to be some kind of way to pass the requirement of the destination content to whatever method creates the `mta.yaml`, because this is what happens when the selected deployment platform is the `SAP Fiori Launchpad` instead of `SAP HTML5 Application Repository service for SAP BTP`. In that case, the destination content is already there "out of the box".
Anyhow, I would still consider this a decent fix for the issue.