### PR TITLE
fix: add destination content to mta.yaml #49

### DIFF
--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -150,6 +150,7 @@ module.exports = class extends Generator {
 
     async writing() {
         const sModuleName = this.options.oneTimeConfig.modulename;
+        const sProjectName = this.options.oneTimeConfig.projectname;
         const localResources =
             this.options.oneTimeConfig.ui5libs === "Local resources (OpenUI5)" ||
             this.options.oneTimeConfig.ui5libs === "Local resources (SAPUI5)";
@@ -348,34 +349,29 @@ module.exports = class extends Generator {
             });
         }
 
-        if (
-            platformIsHTML5AppRepo ||
-            platformIsLaunchpad
-        ) {
-            if (platformIsLaunchpad) {
-                this.log("configuring Launchpad integration...");
-                await fileaccess.manipulateJSON.call(this, "/" + sModuleName + "/webapp/manifest.json", {
-                    ["sap.cloud"]: {
-                        service: this.options.oneTimeConfig.projectname + ".service"
-                    },
-                    ["sap.app"]: {
-                        crossNavigation: {
-                            inbounds: {
-                                intent1: {
-                                    signature: {
-                                        parameters: {},
-                                        additionalParameters: "allowed"
-                                    },
-                                    semanticObject: sModuleName,
-                                    action: "display",
-                                    title: this.options.oneTimeConfig.tilename,
-                                    icon: "sap-icon://add"
-                                }
+        if (platformIsLaunchpad) {
+            this.log("configuring Launchpad integration...");
+            await fileaccess.manipulateJSON.call(this, "/" + sModuleName + "/webapp/manifest.json", {
+                ["sap.cloud"]: {
+                    service: this.options.oneTimeConfig.projectname + ".service"
+                },
+                ["sap.app"]: {
+                    crossNavigation: {
+                        inbounds: {
+                            intent1: {
+                                signature: {
+                                    parameters: {},
+                                    additionalParameters: "allowed"
+                                },
+                                semanticObject: sModuleName,
+                                action: "display",
+                                title: this.options.oneTimeConfig.tilename,
+                                icon: "sap-icon://add"
                             }
                         }
                     }
-                });
-            }
+                }
+            });
         }
 
         // Append to Main package.json
@@ -422,6 +418,62 @@ module.exports = class extends Generator {
                         "supported-platforms": []
                     }
                 });
+
+                //add destination content to mta.yaml so it will be displayed under "HTML5 Applications" in SAP BTP Cockpit
+                if (platformIsHTML5AppRepo) {
+                    mta.modules.push({
+                        "name": `${sProjectName}_destination_content`,
+                        "type": "com.sap.application.content",
+                        "build-parameters": {
+                            "no-source": true,
+                        },
+                        "requires": [{
+                            "name": `${sProjectName}_uaa`,
+                            "parameters": {
+                                "service-key": {
+                                    "name": `${sProjectName}_uaa_key`
+                                }
+                            }
+                        },
+                        {
+                            "name": `${sProjectName}_html5_repo_host`,
+                            "parameters": {
+                                "service-key": {
+                                    "name": `${sProjectName}_html5_repo_host_key`
+                                }
+                            }
+                        },
+                        {
+                            "name": `${sProjectName}_destination`,
+                            "parameters": {
+                                "content-target": true
+                            }
+                        }],
+                        "parameters": {
+                            "content": {
+                                "instance": {
+                                    "existing_destinations_policy": "update",
+                                    "destinations": [
+                                        {
+                                            "Name": `${sProjectName}_destination_html5`,
+                                            "ServiceInstanceName": `${sProjectName}_html5_repo_host`,
+                                            "ServiceKeyName": `${sProjectName}_html5_repo_host_key`,
+                                            "sap.cloud.service": this.options.oneTimeConfig.projectname + ".service"
+                                        },
+                                        {
+                                            "Name": `${sProjectName}_destination_uaa`,
+                                            "Authentication": "OAuth2UserTokenExchange",
+                                            "ServiceInstanceName": `${sProjectName}_uaa`,
+                                            "ServiceKeyName": `${sProjectName}_uaa_key`,
+                                            "sap.cloud.service": this.options.oneTimeConfig.projectname + ".service"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    });
+                }
+                
                 return mta;
             });
         }


### PR DESCRIPTION
This is aiming to fix https://github.com/ui5-community/generator-ui5-project/issues/49.
I added the destination content to the `mta.yaml` after it is being created so that the application will be displayed in the HTML5 Application Repository in the SAP BTP Cockpit (after deployment).
Unfortunately I couldn't really figure out where the `mta.yaml` gets created initially. There has to be some kind of way to pass the requirement of the destination content to whatever method creates the `mta.yaml`, because this is what happens when the selected deployment platform is the SAP Fiori Launchpad instead of SAP HTML5 Application Repository service for SAP BTP. In that case, the destination content is already there "out of the box".
Anyhow, I would still consider this a decent fix for the issue.