### PR TITLE
fix(newfpmpage): typo in error handling

### DIFF
--- a/generators/newfpmpage/index.js
+++ b/generators/newfpmpage/index.js
@@ -70,7 +70,7 @@ module.exports = class extends Generator {
                     if (service.defaults?.auth?.username) {
                         this.log.error(error.cause.statusText);
                     }
-                    if (error.cayse && error.cause.status === 401) {
+                    if (error.cause && error.cause.status === 401) {
                         const { username, password } = await this.prompt([
                             {
                                 type: 'input',


### PR DESCRIPTION
due to a typo in the error handling the username and password cannot be retrieved
I noticed because I tried it myself and only by looking at the source code I found the error.

Yeah Open Source 🎉