### PR TITLE
feat: add prompt for git repo initialization

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -109,6 +109,12 @@ module.exports = class extends Generator {
                 name: "codeassist",
                 message: "Would you like to add JavaScript code assist libraries to the project?",
                 default: true
+            },
+            {
+                type: "confirm",
+                name: "initrepo",
+                message: "Would you like to initialize a local git repository for the project?",
+                default: true
             }
         ]);
         
@@ -264,18 +270,20 @@ module.exports = class extends Generator {
                 cwd: this.destinationPath()
             });
         }
-        this.spawnCommandSync("git", ["init", "--quiet"], {
-            cwd: this.destinationPath()
-        });
-        this.spawnCommandSync("git", ["add", "."], {
-            cwd: this.destinationPath()
-        });
-        this.spawnCommandSync(
-            "git",
-            ["commit", "--quiet", "--allow-empty", "-m", "Initialize repository with easy-ui5"],
-            {
+        if (this.config.initrepo) {
+            this.spawnCommandSync("git", ["init", "--quiet"], {
                 cwd: this.destinationPath()
-            }
-        );
+            });
+            this.spawnCommandSync("git", ["add", "."], {
+                cwd: this.destinationPath()
+            });
+            this.spawnCommandSync(
+                "git",
+                ["commit", "--quiet", "--allow-empty", "-m", "Initialize repository with easy-ui5"],
+                {
+                    cwd: this.destinationPath()
+                }
+            );
+        }
     }
 };


### PR DESCRIPTION
https://github.com/SAP/generator-easy-ui5/issues/109

> A `confirm` option with the name `initrepo` is added to the `prompts` array and in the end function git initialization steps are only performed if `this.config.initrepo` is true (the default value).

credits: [dfenerski](https://github.com/dfenerski)