### PR TITLE
use latest open-ux-tools modules to fix namespace issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-template-ui5-project",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "(Sub-)generator for a UI5 project",
   "main": "generators/app/index.js",
   "scripts": {


### PR DESCRIPTION
Fixes: #55 

* generated projects using the `@sap-ux/fiori-freestyle-writer` contained an incorrect namespace in the App controller
* this fix updates the used version to the currently latest one containing a fix of the ns issue