### PR TITLE
Remove reference to ui5-tooling-modules in FPM TS support

### DIFF
--- a/generators/newwebapp/index.js
+++ b/generators/newwebapp/index.js
@@ -211,7 +211,6 @@ module.exports = class extends Generator {
                                     "ui5-middleware-livereload",
                                     "@sap/ux-ui5-tooling",
                                     "@sap-ux/ui5-middleware-fe-mockserver",
-                                    "ui5-tooling-modules",
                                     "ui5-tooling-transpile"
                                   ]
                             }


### PR DESCRIPTION
If we reference `ui5-tooling-modules`, we do get an error when trying to preview/run the application:

```
❯ npm run start

> travel@0.0.1 start
> ui5 serve --config=uimodule/ui5.yaml  --open index.html?sap-ui-xx-viewCache=false


⚠️  Process Failed With Error

Error Message:
[npm translator] Module ui5-tooling-modules is defined as UI5 dependency but missing from npm dependencies of module travel
```

@tobiasqueck please have a look
