### PR TITLE
Update approuter dep and node version

### DIFF
--- a/generators/additionalmodules/templates/approuter/package.json
+++ b/generators/additionalmodules/templates/approuter/package.json
@@ -2,12 +2,12 @@
   "name": "<%= projectname %>",
   "version": "0.0.1",
   "engines": {
-    "node": "12.X"
+    "node": "14.X"
   },
   "scripts": {
     "start": "node node_modules/@sap/approuter/approuter.js"
   },
   "dependencies": {
-    "@sap/approuter": "^9.0.0"
+    "@sap/approuter": "^11.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-template-ui5-project",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "(Sub-)generator for a UI5 project",
   "main": "generators/app/index.js",
   "scripts": {


### PR DESCRIPTION
Node^12 has reached its end of life (see [here](https://github.com/nodejs/Release)) and also Cloud Foundry no longer comes with the respective buildpack (see [here](https://github.com/cloudfoundry/nodejs-buildpack/releases))