### PR TITLE
fix: adapt deprecated Prettier cli option `--plugin-search-dir` in generated project

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -183,8 +183,8 @@ export default class extends Generator {
                 "karma-ci": "karma start karma-ci.conf.js",
                 clearCoverage: "shx rm -rf coverage",
                 karma: "run-s clearCoverage karma-ci",
-                lint: "eslint ./**/webapp/**/*.js && prettier --plugin-search-dir=. --check ./**/webapp/**/*.{js,xml} --no-error-on-unmatched-pattern",
-                "lint-fix": "eslint ./**/webapp/**/*.js --fix && prettier --plugin-search-dir=. --write ./**/webapp/**/*.{js,xml} --no-error-on-unmatched-pattern"
+                lint: "eslint ./**/webapp/**/*.js && prettier --plugin=@prettier/plugin-xml --check ./**/webapp/**/*.{js,xml} --no-error-on-unmatched-pattern",
+                "lint-fix": "eslint ./**/webapp/**/*.js --fix && prettier --plugin=@prettier/plugin-xml --write ./**/webapp/**/*.{js,xml} --no-error-on-unmatched-pattern"
             },
             devDependencies: {
                 shx: "^0.3.4",


### PR DESCRIPTION
This PR should fix the following issues as recommended in [Prettier documentation](https://prettier.io/blog/2023/07/05/3.0.0.html#plugin-search-feature-has-been-removed-14759httpsgithubcomprettierprettierpull14759-by-fiskerhttpsgithubcomfisker)
- https://github.com/SAP/generator-easy-ui5/issues/138
- https://github.com/SAP/generator-easy-ui5/issues/134
- https://github.com/sap-tutorials/Tutorials/issues/23327

### Background
The previously generated project used `prettier --plugin-search-dir` in its `package.json` scripts with Prettier version set to `latest`, but `--plugin-search-dir` [has been deprecated by Prettier since version 3.0](https://prettier.io/blog/2023/07/05/3.0.0.html#plugin-search-feature-has-been-removed-14759httpsgithubcomprettierprettierpull14759-by-fiskerhttpsgithubcomfisker).
