### PR TITLE
Feat add specific unit and opa5 test templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ test-output/
 
 .DS_Store
 .marskman.toml
+
+# IntelliJ project settings
+.idea
+# VSCode project settings
+.vscode

--- a/generators/dependencies.js
+++ b/generators/dependencies.js
@@ -4,7 +4,7 @@ export default {
 	"@sap-ux/eslint-plugin-fiori-tools": "^0.2",
 	"@sap/approuter": "latest",
 	"@ui5/linter": "latest",
-    "@types/qunit": "2.5.4",
+	"@types/qunit": "2.5.4",
 	"mbt": "^1",
 	"rimraf": "latest",
 	"OpenUI5": "1.120.13",

--- a/generators/dependencies.js
+++ b/generators/dependencies.js
@@ -4,6 +4,7 @@ export default {
 	"@sap-ux/eslint-plugin-fiori-tools": "^0.2",
 	"@sap/approuter": "latest",
 	"@ui5/linter": "latest",
+	"@types/qunit": "2.5.4",
 	"bestzip": "latest",
 	"mbt": "^1",
 	"npm-run-all": "^4",

--- a/generators/dependencies.js
+++ b/generators/dependencies.js
@@ -6,7 +6,6 @@ export default {
 	"@sap/approuter": "latest",
 	"@ui5/linter": "latest",
 	"cds-plugin-ui5": "latest",
-    "@types/qunit": "2.5.4",
 	"mbt": "^1",
 	"rimraf": "latest",
 	"OpenUI5": "1.120.13",

--- a/generators/opa5/index.js
+++ b/generators/opa5/index.js
@@ -38,8 +38,8 @@ export default class extends Generator {
 
 		this.fs.copyTpl(
 			// for some reason this.templatePath() doesn't work here
-			path.join(__dirname, "templates/pages/View.js"),
-			this.destinationPath(`webapp/test/integration/pages/${this.options.config.viewName}.js`),
+			path.join(__dirname, `templates/pages/View.${this.options.config.enableTypescript ? "ts": "js"}`),
+			this.destinationPath(`webapp/test/integration/pages/${this.options.config.viewName}.${this.options.config.enableTypescript ? "ts": "js"}`),
 			{
 				viewName: this.options.config.viewName,
 				uimoduleName: this.options.config.uimoduleName,
@@ -48,8 +48,8 @@ export default class extends Generator {
 		)
 		this.fs.copyTpl(
 			// for some reason this.templatePath() doesn't work here
-			path.join(__dirname, "templates/Journey.js"),
-			this.destinationPath(`webapp/test/integration/${this.options.config.testName}Journey.js`),
+			path.join(__dirname, `templates/Journey.${this.options.config.enableTypescript ? "ts": "js"}`),
+			this.destinationPath(`webapp/test/integration/${this.options.config.testName}Journey.${this.options.config.enableTypescript ? "ts": "js"}`),
 			{
 				viewName: this.options.config.viewName,
 				uimoduleName: this.options.config.uimoduleName,

--- a/generators/opa5/index.js
+++ b/generators/opa5/index.js
@@ -9,6 +9,7 @@ import {
 } from "../helpers.js"
 import path, { dirname } from "path"
 import { fileURLToPath } from "url"
+import dependencies from "../dependencies.js";
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default class extends Generator {
@@ -59,6 +60,12 @@ export default class extends Generator {
 
 		const uimodulePackageJson = JSON.parse(fs.readFileSync(this.destinationPath("package.json")))
 		uimodulePackageJson.scripts["opa5"] = "fiori run --open test/opaTests.qunit.html"
+		if (this.options.config.enableTypescript) {
+			uimodulePackageJson["devDependencies"]["@types/qunit"] = dependencies["@types/qunit"]
+			const tsconfigJson = JSON.parse(fs.readFileSync(this.destinationPath("tsconfig.json")))
+			tsconfigJson.compilerOptions.types.includes("qunit") || tsconfigJson.compilerOptions.types.push( "qunit" )
+			fs.writeFileSync(this.destinationPath("tsconfig.json"), JSON.stringify(tsconfigJson, null, 4))
+		}
 		fs.writeFileSync(this.destinationPath("package.json"), JSON.stringify(uimodulePackageJson, null, 4))
 	}
 

--- a/generators/opa5/index.js
+++ b/generators/opa5/index.js
@@ -9,7 +9,6 @@ import {
 } from "../helpers.js"
 import path, { dirname } from "path"
 import { fileURLToPath } from "url"
-import dependencies from "../dependencies.js";
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default class extends Generator {
@@ -28,6 +27,8 @@ export default class extends Generator {
 			// prioritize manually passed parameter over config from file, as the latter is not up to date when subgenerator is composed
 			this.options.config.uimoduleName = this.options.uimoduleName
 		}
+		// remember tests were generated for post-processing to add the respective types to .tsconfig as well
+		this.options.config.enableTests = true
 	}
 
 	async writing() {
@@ -60,12 +61,6 @@ export default class extends Generator {
 
 		const uimodulePackageJson = JSON.parse(fs.readFileSync(this.destinationPath("package.json")))
 		uimodulePackageJson.scripts["opa5"] = "fiori run --open test/opaTests.qunit.html"
-		if (this.options.config.enableTypescript) {
-			uimodulePackageJson["devDependencies"]["@types/qunit"] = dependencies["@types/qunit"]
-			const tsconfigJson = JSON.parse(fs.readFileSync(this.destinationPath("tsconfig.json")))
-			tsconfigJson.compilerOptions.types.includes("qunit") || tsconfigJson.compilerOptions.types.push( "qunit" )
-			fs.writeFileSync(this.destinationPath("tsconfig.json"), JSON.stringify(tsconfigJson, null, 4))
-		}
 		fs.writeFileSync(this.destinationPath("package.json"), JSON.stringify(uimodulePackageJson, null, 4))
 	}
 

--- a/generators/opa5/templates/Journey.ts
+++ b/generators/opa5/templates/Journey.ts
@@ -13,7 +13,7 @@ QUnit.module("<%= viewName %>");
 
 opaTest("Should have correct title", function() {
 	// Arrangements
-	onThe<%= viewName %>Page.iStartMyUIComponent({
+	void onThe<%= viewName %>Page.iStartMyUIComponent({
 		componentConfig: {
 			name: "<%= uimoduleName %>",
 			async: true
@@ -24,5 +24,5 @@ opaTest("Should have correct title", function() {
 	onThe<%= viewName %>Page.theTitleShouldBeCorrect();
 
 	// Cleanup
-	onThe<%= viewName %>Page.iTeardownMyApp();
+	void onThe<%= viewName %>Page.iTeardownMyApp();
 });

--- a/generators/opa5/templates/Journey.ts
+++ b/generators/opa5/templates/Journey.ts
@@ -17,8 +17,7 @@ opaTest("Should have correct title", function() {
 		componentConfig: {
 			name: "<%= uimoduleName %>",
 			async: true
-		},
-		hash: "<%= route %>"
+		}
 	});
 
 	// Assertions

--- a/generators/opa5/templates/Journey.ts
+++ b/generators/opa5/templates/Journey.ts
@@ -1,0 +1,29 @@
+import Opa5 from "sap/ui/test/Opa5";
+import opaTest from "sap/ui/test/opaQunit";
+import <%= viewName %>Page from "./pages/<%= viewName %>";
+
+const onThe<%= viewName %>Page = new <%= viewName %>Page();
+
+Opa5.extendConfig({
+	viewNamespace: "<%= uimoduleName %>.view",
+	autoWait: true
+});
+
+QUnit.module("<%= viewName %>");
+
+opaTest("Should have correct title", function() {
+	// Arrangements
+	onThe<%= viewName %>Page.iStartMyUIComponent({
+		componentConfig: {
+			name: "<%= uimoduleName %>",
+			async: true
+		},
+		hash: "<%= route %>"
+	});
+
+	// Assertions
+	onThe<%= viewName %>Page.theTitleShouldBeCorrect();
+
+	// Cleanup
+	onThe<%= viewName %>Page.iTeardownMyApp();
+});

--- a/generators/opa5/templates/pages/View.ts
+++ b/generators/opa5/templates/pages/View.ts
@@ -1,0 +1,25 @@
+import Opa5 from "sap/ui/test/Opa5";
+import I18NText from "sap/ui/test/matchers/I18NText";
+
+const viewName = "<%= viewName %>";
+
+export default class <%= viewName %>Page extends Opa5 {
+	//Actions
+
+	//Assertions
+	theTitleShouldBeCorrect(this: Opa5) {
+		this.waitFor({
+			id: "page",
+			viewName,
+			matchers: new I18NText({
+				key: '<%- route === "" ? "title" : route %>',
+				propertyName: 'title',
+				parameters: '<%- route === "" ? uimoduleName : viewName %>'
+			}),
+			success: function() {
+				Opa5.assert.ok(true, "The page has the correct title");
+			},
+			errorMessage: "The page does not have the correct title"
+		});
+	}
+}

--- a/generators/qunit/index.js
+++ b/generators/qunit/index.js
@@ -1,7 +1,6 @@
 import chalk from "chalk"
 import fs from "fs"
 import Generator from "yeoman-generator"
-import dependencies from "../dependencies.js"
 import prompts from "./prompts.js"
 import {
 	lookForParentUI5ProjectAndPrompt,
@@ -25,6 +24,8 @@ export default class extends Generator {
 			// prioritize manually passed parameter over config from file, as the latter is not up to date when subgenerator is composed
 			this.options.config.uimoduleName = this.options.uimoduleName
 		}
+		// remember tests were generated for post-processing to add the respective types to .tsconfig as well
+		this.options.config.enableTests = true
 	}
 
 	async writing() {
@@ -43,12 +44,6 @@ export default class extends Generator {
 
 		const uimodulePackageJson = JSON.parse(fs.readFileSync(this.destinationPath("package.json")))
 		uimodulePackageJson.scripts["qunit"] = "fiori run --open test/unitTests.qunit.html"
-		if (this.options.config.enableTypescript) {
-			uimodulePackageJson["devDependencies"]["@types/qunit"] = dependencies["@types/qunit"]
-			const tsconfigJson = JSON.parse(fs.readFileSync(this.destinationPath("tsconfig.json")))
-			tsconfigJson.compilerOptions.types.includes("qunit") || tsconfigJson.compilerOptions.types.push( "qunit" )
-			fs.writeFileSync(this.destinationPath("tsconfig.json"), JSON.stringify(tsconfigJson, null, 4))
-		}
 		fs.writeFileSync(this.destinationPath("package.json"), JSON.stringify(uimodulePackageJson, null, 4))
 	}
 

--- a/generators/qunit/index.js
+++ b/generators/qunit/index.js
@@ -1,6 +1,7 @@
 import chalk from "chalk"
 import fs from "fs"
 import Generator from "yeoman-generator"
+import dependencies from "../dependencies.js"
 import prompts from "./prompts.js"
 import {
 	lookForParentUI5ProjectAndPrompt,
@@ -33,15 +34,26 @@ export default class extends Generator {
 
 		addPreviewMiddlewareTestConfig.call(this, "Qunit")
 
-		this.fs.copyTpl(
-			// for some reason this.templatePath() doesn't work here
-			path.join(__dirname, "templates/Test.js"),
-			this.destinationPath(`webapp/test/unit/${this.options.config.testName}Test.js`),
-			{ testName: this.options.config.testName }
-		)
-
 		const uimodulePackageJson = JSON.parse(fs.readFileSync(this.destinationPath("package.json")))
 		uimodulePackageJson.scripts["qunit"] = "fiori run --open test/unitTests.qunit.html"
+
+		if (this.options.config.enableTypescript) {
+			this.fs.copyTpl(
+				// for some reason this.templatePath() doesn't work here
+				path.join(__dirname, "templates/Test.ts"),
+				this.destinationPath(`webapp/test/unit/${this.options.config.testName}Test.ts`),
+				{testName: this.options.config.testName}
+			)
+			uimodulePackageJson["devDependencies"]["@types/qunit"] = dependencies["@types/qunit"]
+		} else {
+			this.fs.copyTpl(
+				// for some reason this.templatePath() doesn't work here
+				path.join(__dirname, "templates/Test.js"),
+				this.destinationPath(`webapp/test/unit/${this.options.config.testName}Test.js`),
+				{testName: this.options.config.testName}
+			)
+		}
+
 		fs.writeFileSync(this.destinationPath("package.json"), JSON.stringify(uimodulePackageJson, null, 4))
 	}
 

--- a/generators/qunit/index.js
+++ b/generators/qunit/index.js
@@ -45,6 +45,9 @@ export default class extends Generator {
 		uimodulePackageJson.scripts["qunit"] = "fiori run --open test/unitTests.qunit.html"
 		if (this.options.config.enableTypescript) {
 			uimodulePackageJson["devDependencies"]["@types/qunit"] = dependencies["@types/qunit"]
+			const tsconfigJson = JSON.parse(fs.readFileSync(this.destinationPath("tsconfig.json")))
+			tsconfigJson.compilerOptions.types.includes("qunit") || tsconfigJson.compilerOptions.types.push( "qunit" )
+			fs.writeFileSync(this.destinationPath("tsconfig.json"), JSON.stringify(tsconfigJson, null, 4))
 		}
 		fs.writeFileSync(this.destinationPath("package.json"), JSON.stringify(uimodulePackageJson, null, 4))
 	}

--- a/generators/qunit/index.js
+++ b/generators/qunit/index.js
@@ -34,26 +34,18 @@ export default class extends Generator {
 
 		addPreviewMiddlewareTestConfig.call(this, "Qunit")
 
+		this.fs.copyTpl(
+			// for some reason this.templatePath() doesn't work here
+			path.join(__dirname, `templates/Test.${this.options.config.enableTypescript ? "ts": "js"}`),
+			this.destinationPath(`webapp/test/unit/${this.options.config.testName}Test.${this.options.config.enableTypescript ? "ts": "js"}`),
+			{testName: this.options.config.testName}
+		)
+
 		const uimodulePackageJson = JSON.parse(fs.readFileSync(this.destinationPath("package.json")))
 		uimodulePackageJson.scripts["qunit"] = "fiori run --open test/unitTests.qunit.html"
-
 		if (this.options.config.enableTypescript) {
-			this.fs.copyTpl(
-				// for some reason this.templatePath() doesn't work here
-				path.join(__dirname, "templates/Test.ts"),
-				this.destinationPath(`webapp/test/unit/${this.options.config.testName}Test.ts`),
-				{testName: this.options.config.testName}
-			)
 			uimodulePackageJson["devDependencies"]["@types/qunit"] = dependencies["@types/qunit"]
-		} else {
-			this.fs.copyTpl(
-				// for some reason this.templatePath() doesn't work here
-				path.join(__dirname, "templates/Test.js"),
-				this.destinationPath(`webapp/test/unit/${this.options.config.testName}Test.js`),
-				{testName: this.options.config.testName}
-			)
 		}
-
 		fs.writeFileSync(this.destinationPath("package.json"), JSON.stringify(uimodulePackageJson, null, 4))
 	}
 

--- a/generators/qunit/templates/Test.ts
+++ b/generators/qunit/templates/Test.ts
@@ -1,0 +1,6 @@
+QUnit.module("<%= testName %> Test", {});
+
+QUnit.test("It is just true", assert => {
+    // Assert
+    assert.strictEqual(true, true);
+});

--- a/generators/uimodule/index.js
+++ b/generators/uimodule/index.js
@@ -137,6 +137,11 @@ export default class extends Generator {
 			tsconfigJson.compilerOptions.types = [ "@sapui5/types" ]
 			fs.writeFileSync(this.destinationPath("tsconfig.json"), JSON.stringify(tsconfigJson, null, 4))
 		}
+		if (this.options.config.enableTypescript && this.options.config.enableTests) {
+			const tsconfigJson = JSON.parse(fs.readFileSync(this.destinationPath("tsconfig.json")))
+			tsconfigJson.compilerOptions.types.includes("qunit") || tsconfigJson.compilerOptions.types.push( "qunit" )
+			fs.writeFileSync(this.destinationPath("tsconfig.json"), JSON.stringify(tsconfigJson, null, 4))
+		}
 	}
 
 	end() {

--- a/test/all-projects.js
+++ b/test/all-projects.js
@@ -112,10 +112,17 @@ export const allProjects = (testCase, testDir, projectId, uimoduleName, uimodule
 	})
 
 	it("should have qunit test", async function() {
-		assert.fileContent(
-			path.join(uimodulePath, "webapp/test/unit/FirstTest.js"),
-			"QUnit"
-		)
+		if (testCase.enableTypescript) {
+			assert.fileContent(
+				path.join(uimodulePath, "webapp/test/unit/FirstTest.ts"),
+				"QUnit"
+			)
+		} else {
+			assert.fileContent(
+				path.join(uimodulePath, "webapp/test/unit/FirstTest.js"),
+				"QUnit"
+			)
+		}
 	})
 
 	if (!testCase.enableFPM) {
@@ -131,10 +138,17 @@ export const allProjects = (testCase, testDir, projectId, uimoduleName, uimodule
 		})
 
 		it("should have opa5 journey and page object", async function() {
-			assert.fileContent(
-				path.join(uimodulePath, "webapp/test/integration/FirstJourney.js"),
-				"Opa5"
-			)
+			if (testCase.enableTypescript) {
+				assert.fileContent(
+					path.join(uimodulePath, "webapp/test/integration/FirstJourney.ts"),
+					"Opa5"
+				)
+			} else {
+				assert.fileContent(
+					path.join(uimodulePath, "webapp/test/integration/FirstJourney.js"),
+					"Opa5"
+				)
+			}
 			assert.file(path.join(uimodulePath, "webapp/test/integration/pages"))
 		})
 	}


### PR DESCRIPTION
In case the project is a TypeScript project the generator should generate `.ts` files for opa5 and unit tests

Out of scope for this PR: In case the project is a Fiori Elements (fpmpage) project the generator should make use of sap.fe.test in the generated opa5 tests

Depends on https://github.com/SAP/open-ux-tools/pull/2164