### PR TITLE
fix(cap): Allow xs-app.json to be stored in project root instead of webapp

### DIFF
--- a/generators/model/index.js
+++ b/generators/model/index.js
@@ -156,7 +156,13 @@ export default class extends Generator {
 
 				case "SAP HTML5 Application Repository Service":
 				case "SAP Build Work Zone, standard edition":
-					xsappJsonPath = this.destinationPath(`${this.options.config.uimoduleName}/webapp/xs-app.json`)
+					// check if file is stored in webapp folder or project root
+					const webappPath = this.destinationPath(`${this.options.config.uimoduleName}/webapp/xs-app.json`)
+					if (fs.existsSync(webappPath)) {
+						xsappJsonPath = webappPath
+					} else {
+						xsappJsonPath = this.destinationPath(`${this.options.config.uimoduleName}/xs-app.json`)
+					}
 					break
 			}
 			const xsappJson = JSON.parse(fs.readFileSync(xsappJsonPath))


### PR DESCRIPTION
Fix for #88 

[CoPilot]
This pull request includes a change to the `generators/model/index.js` file to improve the handling of the `xs-app.json` file path for SAP applications. The most important change is the addition of a check to determine whether the `xs-app.json` file is located in the `webapp` folder or the project root.

Improvement to file path handling:

* [`generators/model/index.js`](diffhunk://#diff-c777bb6b91ea11eee1e373247b0fa196e63dcb59eeb0850dea2102ca3d2eaacbL159-R165): Added logic to check if `xs-app.json` is in the `webapp` folder or the project root, ensuring the correct path is used.