### PR TITLE
feat(cap): Allow for dynamic choice of CAP capabilities

### DIFF
--- a/generators/cap/capabilities.js
+++ b/generators/cap/capabilities.js
@@ -8,8 +8,6 @@ export default [
     { name: "html5-repo", checked: true },
     { name: "portal", checked: false },
     // Deployment
-    { name: "mta", checked: true },
-    { name: "cf-manifest", checked: false },
     { name: "helm", checked: false },
     { name: "helm-unified-runtime", checked: false },
     { name: "containerize", checked: false },

--- a/generators/cap/capabilities.js
+++ b/generators/cap/capabilities.js
@@ -17,7 +17,7 @@ export default [
     // Security
     { name: "xsuaa", checked: true },
     // Lintin
-    { name: "lint", checked: true },
+    { name: "lint", checked: false },
     // Typing
     { name: "typer", checked: false },
     { name: "typescript", checked: false },

--- a/generators/cap/capabilities.js
+++ b/generators/cap/capabilities.js
@@ -1,0 +1,53 @@
+export default [
+    // Databases
+    { name: "sqlite", checked: false },
+    { name: "hana", checked: false },
+    { name: "postgres", checked: true },
+    // Runtime
+    { name: "approuter", checked: false },
+    { name: "html5-repo", checked: true },
+    { name: "portal", checked: false },
+    // Deployment
+    { name: "mta", checked: true },
+    { name: "cf-manifest", checked: false },
+    { name: "helm", checked: false },
+    { name: "helm-unified-runtime", checked: false },
+    { name: "containerize", checked: false },
+    { name: "pipeline", checked: false },
+    // Security
+    { name: "xsuaa", checked: true },
+    // Lintin
+    { name: "lint", checked: true },
+    // Typing
+    { name: "typer", checked: false },
+    { name: "typescript", checked: false },
+    // Samples & Sample Data
+    { name: "tiny-sample", checked: true },
+    { name: "sample", checked: false },
+    { name: "data", checked: true },
+    // HTTP
+    { name: "http", checked: true },
+    // Connectivity
+    { name: "connectivity", checked: false },
+    { name: "destination", checked: false },
+    // Logging
+    { name: "application-logging", checked: false },
+    { name: "audit-logging", checked: false },
+    // Messaging
+    { name: "local-messaging", checked: false },
+    { name: "file-based-messaging", checked: false },
+    { name: "enterprise-messaging", checked: false },
+    { name: "enterprise-messaging-shared", checked: false },
+    { name: "redis-messaging", checked: false },
+    { name: "kafka", checked: false },
+    // Notifications
+    { name: "notifications", checked: false },
+    // Attachments
+    { name: "attachments", checked: false },
+    // Feature Toggles
+    { name: "toggles", checked: false },
+    // Multitenancy
+    { name: "multitenancy", checked: false },
+     // Extensibility
+     { name: "extensibility" , checked: false }
+];

--- a/generators/cap/index.js
+++ b/generators/cap/index.js
@@ -29,7 +29,7 @@ export default class extends Generator {
 		this.log(chalk.green(`✨ creating new SAP CAP module for ${this.options.config.projectName}`))
 
 		// TO-DO: check for typescript and configure cap project accordingly
-		this.spawnCommandSync("npx", ["-p", "@sap/cds-dk", "cds", "init", `${this.options.config.capName}`, "--add", "tiny-sample, data, xsuaa, mta, postgres"],
+		this.spawnCommandSync("npx", ["-p", "@sap/cds-dk", "cds", "init", `${this.options.config.capName}`, "--add", this.options.config.capCapabilities.join(",")],
 			this.destinationPath()
 		)
 

--- a/generators/cap/index.js
+++ b/generators/cap/index.js
@@ -28,8 +28,11 @@ export default class extends Generator {
 	async writing() {
 		this.log(chalk.green(`✨ creating new SAP CAP module for ${this.options.config.projectName}`))
 
+		// mta is not an option in the prompts, but it is required for the root mta.yaml
+		const capCapabilities = [...this.options.config.capCapabilities, 'mta']
+
 		// TO-DO: check for typescript and configure cap project accordingly
-		this.spawnCommandSync("npx", ["-p", "@sap/cds-dk", "cds", "init", `${this.options.config.capName}`, "--add", this.options.config.capCapabilities.join(",")],
+		this.spawnCommandSync("npx", ["-p", "@sap/cds-dk", "cds", "init", `${this.options.config.capName}`, "--add", capCapabilities.join(",")],
 			this.destinationPath()
 		)
 

--- a/generators/cap/prompts.js
+++ b/generators/cap/prompts.js
@@ -1,6 +1,7 @@
 import {
 	validateAlphaNumericStartingWithLetterNonEmpty
 } from "../helpers.js"
+import capabilities from "./capabilities.js"
 
 export default async function prompts() {
 
@@ -11,6 +12,13 @@ export default async function prompts() {
 		default: "server",
 		validate: validateAlphaNumericStartingWithLetterNonEmpty
 	})).capName
+
+	this.options.config.capCapabilities = (await this.prompt({
+		type: "checkbox",
+		name: "capCapabilities",
+		message: "Which CAP capabilities do you want to add?",
+        choices: capabilities.map(capability => ({ name: capability.name, value: capability.name, checked: capability.checked })),
+	})).capCapabilities
 	
 	this.options.config.runModelSubgenerator = (await this.prompt({
 		type: "confirm",

--- a/generators/cap/prompts.js
+++ b/generators/cap/prompts.js
@@ -17,7 +17,7 @@ export default async function prompts() {
 		type: "checkbox",
 		name: "capCapabilities",
 		message: "Which CAP capabilities do you want to add?",
-        choices: capabilities.map(capability => ({ name: capability.name, value: capability.name, checked: capability.checked })),
+		choices: capabilities.map(capability => ({ name: capability.name, value: capability.name, checked: capability.checked })),
 	})).capCapabilities
 	
 	this.options.config.runModelSubgenerator = (await this.prompt({

--- a/test/after-project-generation.js
+++ b/test/after-project-generation.js
@@ -15,7 +15,8 @@ export const testCases = [
 		setupRouteTarget: true,
 		controlName: "CustomControl",
 		testName: "Second",
-		capName: "server"
+		capName: "server",
+		capCapabilities: ["postgres", "mta", "xsuaa", "data", "tiny-sample"]
 	},
 	{
 		additionalSubgenerators: ["model", "view", "customcontrol", "qunit", "opa5", "cap", "uimodule"], // run uimodule last to avoid prompts to select between uimodules
@@ -30,7 +31,8 @@ export const testCases = [
 		setupRouteTarget: false,
 		controlName: "CustomControl",
 		testName: "Second",
-		capName: "server"
+		capName: "server",
+		capCapabilities: ["postgres", "mta", "xsuaa", "data", "tiny-sample"]
 	},
 	{
 		additionalSubgenerators: ["model", "view", "customcontrol", "qunit", "opa5", "cap", "uimodule"], // run uimodule last to avoid prompts to select between uimodules
@@ -44,7 +46,8 @@ export const testCases = [
 		setupRouteTarget: false,
 		controlName: "CustomControl",
 		testName: "Second",
-		capName: "server"
+		capName: "server",
+		capCapabilities: ["postgres", "mta", "xsuaa", "data", "tiny-sample"]
 	},
 	{
 		additionalSubgenerators: ["model", "view", "customcontrol", "qunit", "opa5", "cap", "uimodule"], // run uimodule last to avoid prompts to select between uimodules


### PR DESCRIPTION
As of now the CAP capabilities used in cds init are static. This PR adds a checkbox prompt that allows for dynamic choice of CAP capabilities. It checks for the capabilities in the generator install step before executing capability specific code. Dependencies of the CAP service module will be inserted/replaced and not overwritten anymore, since other dependencies like app logging, audit logging, etc could already be added through cds add. 