### PR TITLE
 deps & sap-ux writer upgrades: ESLint migration, writer FS fix, dep bumps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 20
+                  node-version: 24
                   registry-url: https://registry.npmjs.org/
 
             - run: git config --global user.email "cicd@example.com" && git config --global user.name "Your Name"

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ With this option the uimodules gets deployed to SAP NetWeaver using the [deploy-
 Follow these steps to debug this generator (or run it in standalone mode for that matter):
 
 1. Clone this repository.
-1. Start one of the [subgenerators](#subgenerators) in a JavaScript debug terminal within VS Code: `yo ./generators/<subgenerator>`, e.g. `yo ./generators/project`
+1. Start one of the [subgenerators](#subgenerators) in a JavaScript debug terminal within VS Code: `yo ./generators/<subgenerator>`, e.g. `yo ./generators/project` (adjust the path accordingly if running from within an existing application directory)
 
 > If you are feeling really fancy, you can also start a subgenerator via the native Node.js debugger and connect an editor of your choice (any Neovim users here? 👋🏻) via the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/): `node --inspect node_modules/yo/lib/cli.js ui5-project:<subgenerator>`
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Slack OpenUI5 channel][slack-img]][slack-url]  
 [![Build Status][test-image]][test-url]
 [![License Status][license-image]][license-url]
-[![useses node >= 16][node-img]][node-url]
+[![useses node >= 24][node-img]][node-url]
 [![useses nvm][nvm-img]][nvm-url]
 
 A project generator for projects that contain one or more UI5 applications ("uimodules") and manage them via [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces). The uimodules itself use the official UI5 tooling. The generator contains multiple [subgenerators](#subgenerators) to help with recurring tasks. It also supports [multiple deployment targets](#deployment) on the SAP Business Technology Platform. This generator was build as a plug-in for the community project [easy-ui5](https://github.com/SAP/generator-easy-ui5/) by [SAP](https://github.com/SAP/).
@@ -19,15 +19,12 @@ If you are looking to create a simple UI5 project with no deployment configurati
 npm i -g yo generator-easy-ui5
 yo easy-ui5 project
 
-     _-----_
-    |       |    ╭──────────────────────────╮
-    |--(o)--|    │  Welcome to the easy-ui5 │
-   `---------´   │        generator!        │
-    ( _´U`_ )    ╰──────────────────────────╯
-    /___A___\   /
-     |  ~  |
-   __'.___.'__
- ´   `  |° ´ Y `
+  ███████╗ █████╗ ███████╗██╗   ██╗   ██╗   ██╗██╗███████╗     ▄▄ ▄▄ 
+  ██╔════╝██╔══██╗██╔════╝╚██╗ ██╔╝   ██║   ██║██║██╔════╝     █████ 
+  █████╗  ███████║███████╗ ╚████╔╝    ██║   ██║██║███████╗      ███  
+  ██╔══╝  ██╔══██║╚════██║  ╚██╔╝     ██║   ██║██║╚════██║       █   
+  ███████╗██║  ██║███████║   ██║      ╚██████╔╝██║███████║
+  ╚══════╝╚═╝  ╚═╝╚══════╝   ╚═╝       ╚═════╝ ╚═╝╚══════╝
 ```
 
 ## Subgenerators
@@ -205,8 +202,7 @@ With this option the uimodules gets deployed to SAP NetWeaver using the [deploy-
 Follow these steps to debug this generator (or run it in standalone mode for that matter):
 
 1. Clone this repository.
-1. Install the local repository globally via the following command: `npm link`
-1. Start one of the [subgenerators](#subgenerators) in a JavaScript Debug Terminal within VS Code: `yo ui5-project:<subgenerator>`
+1. Start one of the [subgenerators](#subgenerators) in a JavaScript debug terminal within VS Code: `yo ./generators/<subgenerator>`, e.g. `yo ./generators/project`
 
 > If you are feeling really fancy, you can also start a subgenerator via the native Node.js debugger and connect an editor of your choice (any Neovim users here? 👋🏻) via the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/): `node --inspect node_modules/yo/lib/cli.js ui5-project:<subgenerator>`
 

--- a/generators/cap/index.js
+++ b/generators/cap/index.js
@@ -32,8 +32,8 @@ export default class extends Generator {
 		const capCapabilities = [...this.options.config.capCapabilities, 'mta']
 
 		// TO-DO: check for typescript and configure cap project accordingly
-		this.spawnCommandSync("npx", ["-p", "@sap/cds-dk", "cds", "init", `${this.options.config.capName}`, "--nodejs", "--add", capCapabilities.join(",")],
-			this.destinationPath()
+		this.spawnSync("npx", ["-p", "@sap/cds-dk", "cds", "init", `${this.options.config.capName}`, "--nodejs", "--add", capCapabilities.join(",")],
+			{ cwd: this.destinationPath() }
 		)
 
 		addModuleToNPMWorkspaces.call(this, this.options.config.capName)

--- a/generators/dependencies.js
+++ b/generators/dependencies.js
@@ -2,11 +2,9 @@
 // TO-DO: maybe add as peerDependencies for automated security checks via GitHub, then read programmatically from package.json
 export default {
 	"@sap/cds-dk": "^10",
-	"@sap-ux/eslint-plugin-fiori-tools": "^10",
 	"@sap/approuter": "latest",
 	"@ui5/linter": "latest",
 	"cds-plugin-ui5": "latest",
-	"eslint": "^10",
 	"mbt": "^1",
 	"rimraf": "latest",
 	"OpenUI5": "1.148.1",

--- a/generators/dependencies.js
+++ b/generators/dependencies.js
@@ -1,8 +1,8 @@
 // dependencies for generated applications
 // TO-DO: maybe add as peerDependencies for automated security checks via GitHub, then read programmatically from package.json
 export default {
-	"@sap/cds-dk": "^9",
-	"@sap-ux/eslint-plugin-fiori-tools": "^0.2",
+	"@sap/cds-dk": "^10",
+	"@sap-ux/eslint-plugin-fiori-tools": "^10",
 	"@sap/approuter": "latest",
 	"@ui5/linter": "latest",
 	"cds-plugin-ui5": "latest",
@@ -11,5 +11,5 @@ export default {
 	"OpenUI5": "1.148.1",
 	"SAPUI5": "1.148.3",
 	"ui5-middleware-approuter": "^3",
-	"ui5-task-zipper": "^3.2.1"
+	"ui5-task-zipper": "^3"
 }

--- a/generators/dependencies.js
+++ b/generators/dependencies.js
@@ -8,8 +8,8 @@ export default {
 	"cds-plugin-ui5": "latest",
 	"mbt": "^1",
 	"rimraf": "latest",
-	"OpenUI5": "1.136.1",
-	"SAPUI5": "1.136.2",
+	"OpenUI5": "1.148.1",
+	"SAPUI5": "1.148.3",
 	"ui5-middleware-approuter": "^3",
 	"ui5-task-zipper": "^3.2.1"
 }

--- a/generators/dependencies.js
+++ b/generators/dependencies.js
@@ -6,6 +6,7 @@ export default {
 	"@sap/approuter": "latest",
 	"@ui5/linter": "latest",
 	"cds-plugin-ui5": "latest",
+	"eslint": "^10",
 	"mbt": "^1",
 	"rimraf": "latest",
 	"OpenUI5": "1.148.1",

--- a/generators/fpmpage/index.js
+++ b/generators/fpmpage/index.js
@@ -26,10 +26,13 @@ export default class extends Generator {
 
 		// enable fpm
 		const target = this.destinationPath(this.options.config.uimoduleName)
-		enableFPM(target, {
+		await enableFPM(target, {
 			replaceAppComponent: this.options.config.replaceComponent,
 			typescript: this.options.config.enableTypescript || false
 		}, this.fs)
+
+		// commit enableFPM mem-fs changes so manifest can be read via real fs
+		await this.fs.commit()
 
 		const manifestPath = `${this.options.config.uimoduleName}/webapp/manifest.json`
 		const manifestJSON = JSON.parse(fs.readFileSync(this.destinationPath(manifestPath)))
@@ -79,48 +82,11 @@ export default class extends Generator {
 				break
 		}
 
+		// flush mem-fs to disk so subsequent generators (platform, ui5Libs, lint) read FPM-written files
 		if (this.isComposedCall) {
-			// run these here (instead of ../uimodule/index.js) to make sure they get executed after fpmpage
-			this.composeWith(
-				{
-					Generator: PlatformGenerator,
-					path: require.resolve("../uimodule/platform.js")
-				},
-				{
-					config: this.options.config
-				}
-			)
-			this.composeWith(
-				{
-					Generator: UI5LibsGenerator,
-					path: require.resolve("../uimodule/ui5Libs.js")
-				},
-				{
-					config: this.options.config
-				}
-			)
-			this.composeWith(
-				{
-					Generator: LintGenerator,
-					path: require.resolve("../uimodule/lint.js")
-				},
-				{
-					config: this.options.config
-				}
-			)
-			this.composeWith(
-				{
-					Generator: QunitGenerator,
-					path: require.resolve("../qunit")
-				},
-				{
-					config: this.options.config,
-					uimoduleName: this.options.config.uimoduleName
-				}
-			)
-			// this.composeWith(require.resolve("../opa5"), { config: this.options.config, uimoduleName: this.options.config.uimoduleName })
-
+			await this.fs.commit()
 		}
+
 	}
 
 }

--- a/generators/fpmpage/index.js
+++ b/generators/fpmpage/index.js
@@ -1,9 +1,9 @@
 import chalk from "chalk"
-import fpmWriter from "@sap-ux/fe-fpm-writer"
+import { enableFPM, generateObjectPage, generateListReport, generateCustomPage } from "@sap-ux/fe-fpm-writer"
 import fs from "fs"
 import Generator from "yeoman-generator"
 import prompts from "./prompts.js"
-import serviceWriter from "@sap-ux/odata-service-writer"
+import { generate as serviceWriterGenerate, OdataVersion } from "@sap-ux/odata-service-writer"
 import { lookForParentUI5ProjectAndPrompt } from "../helpers.js"
 
 import PlatformGenerator from "../uimodule/platform.js"
@@ -26,7 +26,7 @@ export default class extends Generator {
 
 		// enable fpm
 		const target = this.destinationPath(this.options.config.uimoduleName)
-		fpmWriter.enableFPM(target, {
+		enableFPM(target, {
 			replaceAppComponent: this.options.config.replaceComponent,
 			typescript: this.options.config.enableTypescript || false
 		}, this.fs)
@@ -47,11 +47,11 @@ export default class extends Generator {
 		const uimodulePath = this.destinationPath(this.options.config.uimoduleName)
 
 		if (this.options.config.serviceUrl) {
-			await serviceWriter.generate(uimodulePath, {
+			await serviceWriterGenerate(uimodulePath, {
 				url: this.options.config.host,
 				client: this.options.config.client,
 				path: this.options.config.path,
-				version: serviceWriter.OdataVersion.v4,
+				version: OdataVersion.v4,
 				metadata: this.options.config.metadata,
 				localAnnotationsName: "annotation"
 			}, this.fs)
@@ -59,18 +59,18 @@ export default class extends Generator {
 
 		switch (this.options.config.pageType) {
 			case "object":
-				fpmWriter.generateObjectPage(uimodulePath, {
+				generateObjectPage(uimodulePath, {
 					entity: this.options.config.mainEntity,
 					navigation: navigation
 				}, this.fs)
 				break
 			case "list report":
-				fpmWriter.generateListReport(uimodulePath, {
+				generateListReport(uimodulePath, {
 					entity: this.options.config.mainEntity
 				}, this.fs)
 				break
 			default:
-				fpmWriter.generateCustomPage(uimodulePath, {
+				generateCustomPage(uimodulePath, {
 					name: this.options.config.viewName,
 					entity: this.options.config.mainEntity,
 					navigation: navigation,

--- a/generators/fpmpage/index.js
+++ b/generators/fpmpage/index.js
@@ -6,13 +6,6 @@ import prompts from "./prompts.js"
 import { generate as serviceWriterGenerate, OdataVersion } from "@sap-ux/odata-service-writer"
 import { lookForParentUI5ProjectAndPrompt } from "../helpers.js"
 
-import PlatformGenerator from "../uimodule/platform.js"
-import UI5LibsGenerator from "../uimodule/ui5Libs.js"
-import LintGenerator from "../uimodule/lint.js"
-import QunitGenerator from "../qunit/index.js"
-import { createRequire } from "node:module"
-const require = createRequire(import.meta.url)
-
 export default class extends Generator {
 	static displayName = "Add a page to a Fiori elements FPM application."
 
@@ -62,18 +55,18 @@ export default class extends Generator {
 
 		switch (this.options.config.pageType) {
 			case "object":
-				generateObjectPage(uimodulePath, {
+				await generateObjectPage(uimodulePath, {
 					entity: this.options.config.mainEntity,
 					navigation: navigation
 				}, this.fs)
 				break
 			case "list report":
-				generateListReport(uimodulePath, {
+				await generateListReport(uimodulePath, {
 					entity: this.options.config.mainEntity
 				}, this.fs)
 				break
 			default:
-				generateCustomPage(uimodulePath, {
+				await generateCustomPage(uimodulePath, {
 					name: this.options.config.viewName,
 					entity: this.options.config.mainEntity,
 					navigation: navigation,

--- a/generators/fpmpage/prompts.js
+++ b/generators/fpmpage/prompts.js
@@ -1,4 +1,4 @@
-import axios from "@sap-ux/axios-extension"
+import { createServiceForUrl } from "@sap-ux/axios-extension"
 import fs from "fs"
 import {
 	validateAlphaNumeric,
@@ -31,7 +31,7 @@ export default async function prompts() {
 		if (serviceUrl.searchParams.has("sap-client")) {
 			this.options.config.client = serviceUrl.searchParams.get("sap-client")
 		}
-		const service = axios.createServiceForUrl(serviceUrl, {
+		const service = createServiceForUrl(serviceUrl, {
 			ignoreCertErrors: true
 		})
 

--- a/generators/fpmpage/prompts.js
+++ b/generators/fpmpage/prompts.js
@@ -86,7 +86,7 @@ export default async function prompts() {
 		)
 	}
 	this.options.config.pageType = (await this.prompt({
-		type: "list",
+		type: "select",
 		name: "pageType",
 		message: "What type of page do you want to add?",
 		choices: pageOptions,

--- a/generators/helpers.js
+++ b/generators/helpers.js
@@ -51,7 +51,7 @@ export async function ensureCorrectDestinationPath() {
 export async function addPreviewMiddlewareTestConfig(framework) {
 	const ui5Yaml = yaml.parse(fs.readFileSync(this.destinationPath("ui5.yaml")).toString())
 	const testConfig = { framework: framework }
-	const middlewareName = "preview-middleware"
+	const middlewareName = "fiori-tools-preview"
 
 	let middleware = ui5Yaml.server.customMiddleware.find(m => m.name === middlewareName)
 

--- a/generators/uimodule/index.js
+++ b/generators/uimodule/index.js
@@ -38,10 +38,12 @@ export default class extends Generator {
 			app: {
 				id: this.options.config.uimoduleName,
 				title: this.options.config.tileName || this.options.config.uimoduleName,
-				description: `${this.options.config.uimoduleName} description`
+				description: `${this.options.config.uimoduleName} description`,
+				projectType: "EDMXBackend",
 			},
 			appOptions: {
-				loadReuseLibs: true
+				loadReuseLibs: true,
+				eslint: true
 			},
 			package: {
 				name: this.options.config.uimoduleName
@@ -53,8 +55,8 @@ export default class extends Generator {
 			}
 		}
 
-		// pass appConfig to @sap-ux writers
 		if (this.options.config.enableFPM) {
+			console.log(this.options.config.enableFioriTools)
 			appConfig.appOptions.sapux = this.options.config.enableFioriTools
 			appConfig.app.baseComponent = "sap/fe/core/AppComponent"
 			if (this.options.config.enableTypescript) {
@@ -62,13 +64,6 @@ export default class extends Generator {
 			}
 			const fpmFs = await writeFPMApp(this.destinationPath(), appConfig)
 			await new Promise(resolve => fpmFs.commit(resolve))
-			this.composeWith(
-				{
-					Generator: FPMPageGenerator,
-					path: require.resolve("../fpmpage")
-				},
-				{ config: this.options.config }
-			)
 		} else {
 			appConfig.template = {
 				type: TemplateType.Basic,
@@ -131,6 +126,15 @@ export default class extends Generator {
 					uimoduleName: this.options.config.uimoduleName
 				}
 			)
+			if (this.options.config.enableFPM) {
+				this.composeWith(
+					{
+						Generator: FPMPageGenerator,
+						path: require.resolve("../fpmpage")
+					},
+					{ config: this.options.config }
+				)
+			}
 
 	}
 

--- a/generators/uimodule/index.js
+++ b/generators/uimodule/index.js
@@ -79,11 +79,11 @@ export default class extends Generator {
 			// fiori-freestyle-writer reads ui5-local.yaml before generating it (upstream sap-ux bug)
 			fs.mkdirSync(this.destinationPath(), { recursive: true })
 			fs.writeFileSync(this.destinationPath("ui5-local.yaml"), "specVersion: \"2.6\"")
+
 			const freestyleFs = await writeFreestyleApp(this.destinationPath(), appConfig)
 			await new Promise(resolve => freestyleFs.commit(resolve))
+		}
 
-			// compose with these subgenerators from here only for freestyle apps
-			// for fpm apps these subgenerators have to be called from within ../fpmpage to ensure they run after the fe-fpm-writer doesn't overwrite them
 			this.composeWith(
 				{
 					Generator: PlatformGenerator,
@@ -131,7 +131,7 @@ export default class extends Generator {
 					uimoduleName: this.options.config.uimoduleName
 				}
 			)
-		}
+
 	}
 
 	install() {

--- a/generators/uimodule/index.js
+++ b/generators/uimodule/index.js
@@ -79,6 +79,17 @@ export default class extends Generator {
 			await new Promise(resolve => freestyleFs.commit(resolve))
 		}
 
+			if (this.options.config.enableFPM) {
+				this.composeWith(
+					{
+						Generator: FPMPageGenerator,
+						path: require.resolve("../fpmpage")
+					},
+					{ config: this.options.config }
+				)
+			}
+
+
 			this.composeWith(
 				{
 					Generator: PlatformGenerator,
@@ -126,15 +137,6 @@ export default class extends Generator {
 					uimoduleName: this.options.config.uimoduleName
 				}
 			)
-			if (this.options.config.enableFPM) {
-				this.composeWith(
-					{
-						Generator: FPMPageGenerator,
-						path: require.resolve("../fpmpage")
-					},
-					{ config: this.options.config }
-				)
-			}
 
 	}
 

--- a/generators/uimodule/index.js
+++ b/generators/uimodule/index.js
@@ -70,9 +70,6 @@ export default class extends Generator {
 					viewName: "MainView"
 				}
 			}
-			// fiori-freestyle-writer reads ui5-local.yaml before generating it (upstream sap-ux bug)
-			fs.mkdirSync(this.destinationPath(), { recursive: true })
-			fs.writeFileSync(this.destinationPath("ui5-local.yaml"), "specVersion: \"2.6\"")
 
 			const freestyleFs = await writeFreestyleApp(this.destinationPath(), appConfig)
 			await new Promise(resolve => freestyleFs.commit(resolve))

--- a/generators/uimodule/index.js
+++ b/generators/uimodule/index.js
@@ -60,7 +60,8 @@ export default class extends Generator {
 			if (this.options.config.enableTypescript) {
 				appConfig.appOptions.typescript = true
 			}
-			await writeFPMApp(this.destinationPath(), appConfig, this.fs)
+			const fpmFs = await writeFPMApp(this.destinationPath(), appConfig)
+			await new Promise(resolve => fpmFs.commit(resolve))
 			this.composeWith(
 				{
 					Generator: FPMPageGenerator,
@@ -75,7 +76,11 @@ export default class extends Generator {
 					viewName: "MainView"
 				}
 			}
-			await writeFreestyleApp(this.destinationPath(), appConfig, this.fs)
+			// fiori-freestyle-writer reads ui5-local.yaml before generating it (upstream sap-ux bug)
+			fs.mkdirSync(this.destinationPath(), { recursive: true })
+			fs.writeFileSync(this.destinationPath("ui5-local.yaml"), "specVersion: \"2.6\"")
+			const freestyleFs = await writeFreestyleApp(this.destinationPath(), appConfig)
+			await new Promise(resolve => freestyleFs.commit(resolve))
 
 			// compose with these subgenerators from here only for freestyle apps
 			// for fpm apps these subgenerators have to be called from within ../fpmpage to ensure they run after the fe-fpm-writer doesn't overwrite them

--- a/generators/uimodule/index.js
+++ b/generators/uimodule/index.js
@@ -56,7 +56,6 @@ export default class extends Generator {
 		}
 
 		if (this.options.config.enableFPM) {
-			console.log(this.options.config.enableFioriTools)
 			appConfig.appOptions.sapux = this.options.config.enableFioriTools
 			appConfig.app.baseComponent = "sap/fe/core/AppComponent"
 			if (this.options.config.enableTypescript) {

--- a/generators/uimodule/lint.js
+++ b/generators/uimodule/lint.js
@@ -2,9 +2,6 @@ import dependencies from "../dependencies.js"
 import { ensureCorrectDestinationPath } from "../helpers.js"
 import fs from "fs"
 import Generator from "yeoman-generator"
-import path, { dirname } from "path"
-import { fileURLToPath } from "url"
-const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default class extends Generator {
 
@@ -15,18 +12,6 @@ export default class extends Generator {
 
 		uimodulePackageJson["devDependencies"]["@ui5/linter"] = dependencies["@ui5/linter"]
 		uimodulePackageJson["scripts"]["ui5lint"] = "ui5lint"
-
-		if (!fs.existsSync(this.destinationPath(".eslintrc")) && !fs.existsSync(this.destinationPath("eslint.config.mjs"))) {
-			this.fs.copyTpl(
-				// for some reason this.templatePath() doesn't work here
-				path.join(__dirname, "templates/eslint.config.mjs"),
-				this.destinationPath("eslint.config.mjs"),
-				{}
-			)
-		}
-		uimodulePackageJson["devDependencies"]["eslint"] = dependencies["eslint"]
-		uimodulePackageJson["devDependencies"]["@sap-ux/eslint-plugin-fiori-tools"] = dependencies["@sap-ux/eslint-plugin-fiori-tools"]
-		uimodulePackageJson["scripts"]["lint"] = "eslint ./"
 
 		fs.writeFileSync(this.destinationPath("package.json"), JSON.stringify(uimodulePackageJson, null, 4))
 	}

--- a/generators/uimodule/lint.js
+++ b/generators/uimodule/lint.js
@@ -23,9 +23,10 @@ export default class extends Generator {
 				this.destinationPath("eslint.config.mjs"),
 				{}
 			)
-			uimodulePackageJson["devDependencies"]["@sap-ux/eslint-plugin-fiori-tools"] = dependencies["@sap-ux/eslint-plugin-fiori-tools"]
-			uimodulePackageJson["scripts"]["lint"] = "eslint ./"
 		}
+		uimodulePackageJson["devDependencies"]["eslint"] = dependencies["eslint"]
+		uimodulePackageJson["devDependencies"]["@sap-ux/eslint-plugin-fiori-tools"] = dependencies["@sap-ux/eslint-plugin-fiori-tools"]
+		uimodulePackageJson["scripts"]["lint"] = "eslint ./"
 
 		fs.writeFileSync(this.destinationPath("package.json"), JSON.stringify(uimodulePackageJson, null, 4))
 	}

--- a/generators/uimodule/lint.js
+++ b/generators/uimodule/lint.js
@@ -16,3 +16,4 @@ export default class extends Generator {
 		fs.writeFileSync(this.destinationPath("package.json"), JSON.stringify(uimodulePackageJson, null, 4))
 	}
 }
+

--- a/generators/uimodule/lint.js
+++ b/generators/uimodule/lint.js
@@ -16,11 +16,11 @@ export default class extends Generator {
 		uimodulePackageJson["devDependencies"]["@ui5/linter"] = dependencies["@ui5/linter"]
 		uimodulePackageJson["scripts"]["ui5lint"] = "ui5lint"
 
-		if (!fs.existsSync(this.destinationPath(".eslintrc"))) {
+		if (!fs.existsSync(this.destinationPath(".eslintrc")) && !fs.existsSync(this.destinationPath("eslint.config.mjs"))) {
 			this.fs.copyTpl(
 				// for some reason this.templatePath() doesn't work here
-				path.join(__dirname, "templates/.eslintrc"),
-				this.destinationPath(".eslintrc"),
+				path.join(__dirname, "templates/eslint.config.mjs"),
+				this.destinationPath("eslint.config.mjs"),
 				{}
 			)
 			uimodulePackageJson["devDependencies"]["@sap-ux/eslint-plugin-fiori-tools"] = dependencies["@sap-ux/eslint-plugin-fiori-tools"]

--- a/generators/uimodule/platform.js
+++ b/generators/uimodule/platform.js
@@ -15,6 +15,9 @@ export default class extends Generator {
 		delete uimodulePackageJson.scripts["deploy"]
 		delete uimodulePackageJson.scripts["deploy-config"]
 
+		// we do have a .gitignore at root level
+		fs.unlinkSync(this.destinationPath(".gitignore"))
+
 		switch (this.options.config.platform) {
 			case "Static webserver":
 				uimodulePackageJson.scripts["build"] = `ui5 build --config=ui5.yaml --clean-dest --dest ../dist/${this.options.config.uimoduleName}`

--- a/generators/uimodule/platform.js
+++ b/generators/uimodule/platform.js
@@ -146,7 +146,7 @@ export default class extends Generator {
 
 			ui5Yaml.server.customMiddleware.push(
 				{
-					name: "preview-middleware",
+					name: "fiori-tools-preview",
 					afterMiddleware: "compression",
 					configuration: {
 						flp: {
@@ -160,7 +160,7 @@ export default class extends Generator {
 			uimodulePackageJson.scripts["start-flp"] = "fiori run --open test/flpSandbox.html"
 		}
 
-		// freestyle app template includes launchpad, which we don't need as we use the preview-middleware if needed
+		// freestyle app template includes launchpad, which we don't need as we use the fiori-tools-preview if needed
 		if (!this.options.config.enableFPM) {
 			fs.unlinkSync(this.destinationPath("webapp/test/flpSandbox.html"))
 			fs.unlinkSync(this.destinationPath("webapp/test/locate-reuse-libs.js"))

--- a/generators/uimodule/platform.js
+++ b/generators/uimodule/platform.js
@@ -15,9 +15,6 @@ export default class extends Generator {
 		delete uimodulePackageJson.scripts["deploy"]
 		delete uimodulePackageJson.scripts["deploy-config"]
 
-		// we do have a .gitignore at root level
-		fs.unlinkSync(this.destinationPath(".gitignore"))
-
 		switch (this.options.config.platform) {
 			case "Static webserver":
 				uimodulePackageJson.scripts["build"] = `ui5 build --config=ui5.yaml --clean-dest --dest ../dist/${this.options.config.uimoduleName}`

--- a/generators/uimodule/templates/.eslintrc
+++ b/generators/uimodule/templates/.eslintrc
@@ -1,4 +1,0 @@
-{
-    "extends": "plugin:@sap-ux/eslint-plugin-fiori-tools/defaultTS",
-    "root": true
-}

--- a/generators/uimodule/templates/eslint.config.mjs
+++ b/generators/uimodule/templates/eslint.config.mjs
@@ -1,0 +1,5 @@
+import fioriTools from '@sap-ux/eslint-plugin-fiori-tools';
+
+export default [
+    ...fioriTools.configs.recommended
+];

--- a/generators/uimodule/templates/eslint.config.mjs
+++ b/generators/uimodule/templates/eslint.config.mjs
@@ -1,5 +1,0 @@
-import fioriTools from '@sap-ux/eslint-plugin-fiori-tools';
-
-export default [
-    ...fioriTools.configs.recommended
-];

--- a/generators/uimodule/ui5Libs.js
+++ b/generators/uimodule/ui5Libs.js
@@ -39,26 +39,30 @@ export default class extends Generator {
 				})
 				fs.writeFileSync(
 					this.destinationPath("webapp/index.html"),
-					indexHtml.replace(`src="resources/sap-ui-core.js"`, `src="https://sdk.openui5.org/${dependencies["OpenUI5"]}/resources/sap-ui-core.js"`)
+					indexHtml.replace("https://ui5.sap.com", "https://sdk.openui5.org")
 				)
 				manifestJSON["sap.ui5"]["dependencies"]["minUI5Version"] = dependencies["OpenUI5"]
 				break
 			case "Content delivery network (SAPUI5)":
 				delete ui5Yaml.framework
-				fs.writeFileSync(
-					this.destinationPath("webapp/index.html"),
-					indexHtml.replace(`src="resources/sap-ui-core.js"`, `src="https://ui5.sap.com/${dependencies["SAPUI5"]}/resources/sap-ui-core.js"`)
-				)
 				manifestJSON["sap.ui5"]["dependencies"]["minUI5Version"] = dependencies["SAPUI5"]
 				break
 			case "Local resources (OpenUI5)":
 				localResources = true
+				fs.writeFileSync(
+					this.destinationPath("webapp/index.html"),
+					indexHtml.replace(`https://ui5.sap.com/${dependencies["OpenUI5"]}/resources/sap-ui-core.js`, "resources/sap-ui-core.js")
+				)
 				ui5Yaml.framework.name = "OpenUI5"
 				ui5Yaml.framework.version = dependencies["OpenUI5"]
 				manifestJSON["sap.ui5"]["dependencies"]["minUI5Version"] = dependencies["OpenUI5"]
 				break
 			case "Local resources (SAPUI5)":
 				localResources = true
+				fs.writeFileSync(
+					this.destinationPath("webapp/index.html"),
+					indexHtml.replace(`https://ui5.sap.com/${dependencies["SAPUI5"]}/resources/sap-ui-core.js`, "resources/sap-ui-core.js")
+				)
 				ui5Yaml.framework.name = "SAPUI5"
 				ui5Yaml.framework.version = dependencies["SAPUI5"]
 				manifestJSON["sap.ui5"]["dependencies"]["minUI5Version"] = dependencies["SAPUI5"]

--- a/generators/uimodule/ui5Libs.js
+++ b/generators/uimodule/ui5Libs.js
@@ -105,7 +105,7 @@ export default class extends Generator {
 		fs.writeFileSync(this.destinationPath("webapp/manifest.json"), JSON.stringify(manifestJSON, null, 4))
 
 		// remove option to bootstrap from local UI5 sources, as UI5 source is part of user selection
-		fs.unlinkSync(this.destinationPath("ui5-local.yaml"))
+		if (fs.existsSync(this.destinationPath("ui5-local.yaml"))) fs.unlinkSync(this.destinationPath("ui5-local.yaml"))
 		delete packageJson.scripts["start-local"]
 		fs.unlinkSync(this.destinationPath("package.json")) // avoid conflict/auto-prompt by yeoman
 		fs.writeFileSync(this.destinationPath("package.json"), JSON.stringify(packageJson, null, 4))

--- a/generators/uimodule/ui5Libs.js
+++ b/generators/uimodule/ui5Libs.js
@@ -39,30 +39,26 @@ export default class extends Generator {
 				})
 				fs.writeFileSync(
 					this.destinationPath("webapp/index.html"),
-					indexHtml.replace("https://ui5.sap.com", "https://sdk.openui5.org")
+					indexHtml.replace(`src="resources/sap-ui-core.js"`, `src="https://sdk.openui5.org/${dependencies["OpenUI5"]}/resources/sap-ui-core.js"`)
 				)
 				manifestJSON["sap.ui5"]["dependencies"]["minUI5Version"] = dependencies["OpenUI5"]
 				break
 			case "Content delivery network (SAPUI5)":
 				delete ui5Yaml.framework
+				fs.writeFileSync(
+					this.destinationPath("webapp/index.html"),
+					indexHtml.replace(`src="resources/sap-ui-core.js"`, `src="https://ui5.sap.com/${dependencies["SAPUI5"]}/resources/sap-ui-core.js"`)
+				)
 				manifestJSON["sap.ui5"]["dependencies"]["minUI5Version"] = dependencies["SAPUI5"]
 				break
 			case "Local resources (OpenUI5)":
 				localResources = true
-				fs.writeFileSync(
-					this.destinationPath("webapp/index.html"),
-					indexHtml.replace(`https://ui5.sap.com/${dependencies["OpenUI5"]}/resources/sap-ui-core.js`, "resources/sap-ui-core.js")
-				)
 				ui5Yaml.framework.name = "OpenUI5"
 				ui5Yaml.framework.version = dependencies["OpenUI5"]
 				manifestJSON["sap.ui5"]["dependencies"]["minUI5Version"] = dependencies["OpenUI5"]
 				break
 			case "Local resources (SAPUI5)":
 				localResources = true
-				fs.writeFileSync(
-					this.destinationPath("webapp/index.html"),
-					indexHtml.replace(`https://ui5.sap.com/${dependencies["SAPUI5"]}/resources/sap-ui-core.js`, "resources/sap-ui-core.js")
-				)
 				ui5Yaml.framework.name = "SAPUI5"
 				ui5Yaml.framework.version = dependencies["SAPUI5"]
 				manifestJSON["sap.ui5"]["dependencies"]["minUI5Version"] = dependencies["SAPUI5"]
@@ -109,7 +105,7 @@ export default class extends Generator {
 		fs.writeFileSync(this.destinationPath("webapp/manifest.json"), JSON.stringify(manifestJSON, null, 4))
 
 		// remove option to bootstrap from local UI5 sources, as UI5 source is part of user selection
-		if (fs.existsSync(this.destinationPath("ui5-local.yaml"))) fs.unlinkSync(this.destinationPath("ui5-local.yaml"))
+		fs.unlinkSync(this.destinationPath("ui5-local.yaml"))
 		delete packageJson.scripts["start-local"]
 		fs.unlinkSync(this.destinationPath("package.json")) // avoid conflict/auto-prompt by yeoman
 		fs.writeFileSync(this.destinationPath("package.json"), JSON.stringify(packageJson, null, 4))

--- a/generators/uimodule/ui5Libs.js
+++ b/generators/uimodule/ui5Libs.js
@@ -66,7 +66,7 @@ export default class extends Generator {
 		}
 
 		if (localResources && this.options.config.platform !== "SAP Build Work Zone, standard edition") {
-			// only if no flpSandbox.html exists (via preview-middleware), as it requires proxy to fetch all libs
+			// only if no flpSandbox.html exists (via fiori-tools-preview), as it requires proxy to fetch all libs
 			deleteProxyToUI5(ui5Yaml)
 
 			packageJson.scripts.build = packageJson.scripts.build.replace("ui5 build", "ui5 build self-contained --all --include-task generateVersionInfo")

--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
 		"test": "mocha",
 		"debug:test": "node --inspect node_modules/.bin/_mocha",
 		"dev:project": "yo ./generators/project",
-		"dev:uimodule": "yo ./generators/uimodule",
-		"debug:project": "node --inspect node_modules/yo/lib/cli.js ./generators/project",
-		"debug:uimodule": "node --inspect node_modules/yo/lib/cli.js ./generators/uimodule"
+		"debug:project": "node --inspect node_modules/yo/lib/cli.js ./generators/project"
 	},
 	"devDependencies": {
 		"mocha": "11.7.6",

--- a/package.json
+++ b/package.json
@@ -17,30 +17,30 @@
 	],
 	"main": "generators/project/index.js",
 	"dependencies": {
-		"@sap-ux/axios-extension": "^1.12.0",
-		"@sap-ux/fe-fpm-writer": "^0.24.3",
-		"@sap-ux/fiori-freestyle-writer": "^0.21.3",
-		"@sap-ux/odata-service-writer": "^0.17.2",
-		"@sap-ux/project-access": "^1.16.2",
-		"chalk": "^5.3.0",
-		"path": "^0.12.7",
-		"yaml": "^2.3.4",
-		"yeoman-environment": "^4.1.3",
-		"yeoman-generator": "^7.1.1"
+		"@sap-ux/axios-extension": "2.0.4",
+		"@sap-ux/fe-fpm-writer": "1.1.3",
+		"@sap-ux/fiori-freestyle-writer": "3.0.39",
+		"@sap-ux/odata-service-writer": "1.0.10",
+		"@sap-ux/project-access": "2.1.4",
+		"chalk": "5.6.2",
+		"path": "0.12.7",
+		"yaml": "2.9.0",
+		"yeoman-environment": "6.1.0",
+		"yeoman-generator": "8.2.2"
 	},
 	"scripts": {
 		"test": "mocha",
 		"debug:test": "node --inspect node_modules/.bin/_mocha",
-		"dev:project": "yo ui5-project:project",
-		"dev:uimodule": "yo ui5-project:uimodule",
-		"debug:project": "node --inspect node_modules/yo/lib/cli.js ui5-project:project",
-		"debug:uimodule": "node --inspect node_modules/yo/lib/cli.js ui5-project:uimodule"
+		"dev:project": "yo ./generators/project",
+		"dev:uimodule": "yo ./generators/uimodule",
+		"debug:project": "node --inspect node_modules/yo/lib/cli.js ./generators/project",
+		"debug:uimodule": "node --inspect node_modules/yo/lib/cli.js ./generators/uimodule"
 	},
 	"devDependencies": {
-		"mocha": "^10.4.0",
-		"nock": "^13.5.4",
-		"yeoman-assert": "^3.1.1",
-		"yeoman-test": "^8.3.0",
-		"yo": "^5.0.0"
+		"mocha": "11.7.6",
+		"nock": "14.0.16",
+		"yeoman-assert": "3.1.1",
+		"yeoman-test": "11.6.0",
+		"yo": "7.0.1"
 	}
 }

--- a/test/after-project-generation.js
+++ b/test/after-project-generation.js
@@ -150,7 +150,7 @@ export const tests = (testCase, uimodulePath, uimodulePath2) => {
 	it("should have new opa5 journey and page object", async function() {
 		const fileEnding = testCase.enableTypescript ? "ts" : "js"
 		assert.file(path.join(uimodulePath, `webapp/test/integration/${testCase.testName}Journey.${fileEnding}`))
-		assert.file(path.join(uimodulePath, `webapp/test/integration/pages/${testCase.viewName}.page.${fileEnding}`))
+		assert.file(path.join(uimodulePath, `webapp/test/integration/pages/${testCase.viewName}.${fileEnding}`))
 	})
 
 

--- a/test/all-projects.js
+++ b/test/all-projects.js
@@ -157,15 +157,15 @@ export const allProjects = (testCase, testDir, projectId, uimoduleName, uimodule
 		})
 	}
 
-	// it("should generate an installable project", async function() {
-	// 	return execSync("npm install --loglevel=error", { cwd: path.join(testDir, projectId) })
-	// })
+	it("should generate an installable project", async function() {
+		return execSync("npm install --loglevel=error", { cwd: path.join(testDir, projectId) })
+	})
 
-	// if (testCase.platform !== "SAP NetWeaver") {
-	// 	it("should generate a buildable project", async function() {
-	// 		return execSync("npm run build", { cwd: path.join(testDir, projectId) })
-	// 	})
-	// }
+	if (testCase.platform !== "SAP NetWeaver") {
+		it("should generate a buildable project", async function() {
+			return execSync("npm run build", { cwd: path.join(testDir, projectId) })
+		})
+	}
 
 }
 

--- a/test/all-projects.js
+++ b/test/all-projects.js
@@ -86,7 +86,7 @@ export const allProjects = (testCase, testDir, projectId, uimoduleName, uimodule
 			path.join(uimodulePath, "package.json"),
 			"\"lint\": \"eslint ./\""
 		)
-		assert.file(path.join(uimodulePath, ".eslintrc"))
+		assert.file(path.join(uimodulePath, "eslint.config.mjs"))
 	})
 
 	it("should use @ui5/linter", async function() {
@@ -153,15 +153,15 @@ export const allProjects = (testCase, testDir, projectId, uimoduleName, uimodule
 		})
 	}
 
-	it("should generate an installable project", async function() {
-		return execSync("npm install --loglevel=error", { cwd: path.join(testDir, projectId) })
-	})
+	// it("should generate an installable project", async function() {
+	// 	return execSync("npm install --loglevel=error", { cwd: path.join(testDir, projectId) })
+	// })
 
-	if (testCase.platform !== "SAP NetWeaver") {
-		it("should generate a buildable project", async function() {
-			return execSync("npm run build", { cwd: path.join(testDir, projectId) })
-		})
-	}
+	// if (testCase.platform !== "SAP NetWeaver") {
+	// 	it("should generate a buildable project", async function() {
+	// 		return execSync("npm run build", { cwd: path.join(testDir, projectId) })
+	// 	})
+	// }
 
 }
 

--- a/test/all-projects.js
+++ b/test/all-projects.js
@@ -34,10 +34,10 @@ export const allProjects = (testCase, testDir, projectId, uimoduleName, uimodule
 			)
 		})
 
-		it("should use the preview-middleware for the flpSandbox.html", async function() {
+		it("should use the fiori-tools-preview for the flpSandbox.html", async function() {
 			assert.fileContent(
 				path.join(uimodulePath, "ui5.yaml"),
-				"preview-middleware"
+				"fiori-tools-preview"
 			)
 			assert.fileContent(
 				path.join(uimodulePath, "ui5.yaml"),
@@ -103,7 +103,7 @@ export const allProjects = (testCase, testDir, projectId, uimoduleName, uimodule
 	it("should have basic qunit configuration", async function() {
 		assert.fileContent(
 			path.join(uimodulePath, "ui5.yaml"),
-			"preview-middleware"
+			"fiori-tools-preview"
 		)
 		assert.fileContent(
 			path.join(uimodulePath, "ui5.yaml"),
@@ -129,7 +129,7 @@ export const allProjects = (testCase, testDir, projectId, uimoduleName, uimodule
 		it("should have basic opa5 configuration", async function() {
 			assert.fileContent(
 				path.join(uimodulePath, "ui5.yaml"),
-				"preview-middleware"
+				"fiori-tools-preview"
 			)
 			assert.fileContent(
 				path.join(uimodulePath, "ui5.yaml"),

--- a/test/all-projects.js
+++ b/test/all-projects.js
@@ -86,6 +86,10 @@ export const allProjects = (testCase, testDir, projectId, uimoduleName, uimodule
 			path.join(uimodulePath, "package.json"),
 			"\"lint\": \"eslint ./\""
 		)
+		assert.fileContent(
+			path.join(uimodulePath, "package.json"),
+			"@sap-ux/eslint-plugin-fiori-tools"
+		)
 		assert.file(path.join(uimodulePath, "eslint.config.mjs"))
 	})
 

--- a/test/fpm-projects.js
+++ b/test/fpm-projects.js
@@ -2,35 +2,35 @@ import assert from "yeoman-assert"
 import path from "path"
 
 export const testCases = [
-	// {
-	// 	platform: "Static webserver",
-	// 	enableFPM: true,
-	// 	serviceUrl: "http://localhost:4004/travel",
-	// 	mainEntity: "BookedFlights",
-	// 	enableTypescript: false
-	// },
-	// {
-	// 	platform: "Application Router",
-	// 	enableFPM: true,
-	// 	serviceUrl: "http://localhost:4004/travel",
-	// 	mainEntity: "BookedFlights",
-	// 	enableTypescript: true,
-	// 	newDir: false
-	// },
-	// {
-	// 	platform: "SAP HTML5 Application Repository Service",
-	// 	enableFPM: true,
-	// 	serviceUrl: "http://localhost:4004/travel",
-	// 	mainEntity: "BookedFlights",
-	// 	enableTypescript: true
-	// },
-	// {
-	// 	platform: "SAP Build Work Zone, standard edition",
-	// 	enableFPM: true,
-	// 	serviceUrl: "http://localhost:4004/travel",
-	// 	mainEntity: "BookedFlights",
-	// 	enableTypescript: true
-	// },
+	{
+		platform: "Static webserver",
+		enableFPM: true,
+		serviceUrl: "http://localhost:4004/travel",
+		mainEntity: "BookedFlights",
+		enableTypescript: false
+	},
+	{
+		platform: "Application Router",
+		enableFPM: true,
+		serviceUrl: "http://localhost:4004/travel",
+		mainEntity: "BookedFlights",
+		enableTypescript: true,
+		newDir: false
+	},
+	{
+		platform: "SAP HTML5 Application Repository Service",
+		enableFPM: true,
+		serviceUrl: "http://localhost:4004/travel",
+		mainEntity: "BookedFlights",
+		enableTypescript: true
+	},
+	{
+		platform: "SAP Build Work Zone, standard edition",
+		enableFPM: true,
+		serviceUrl: "http://localhost:4004/travel",
+		mainEntity: "BookedFlights",
+		enableTypescript: true
+	},
 	{
 		platform: "SAP Build Work Zone, standard edition",
 		enableFPM: true,

--- a/test/fpm-projects.js
+++ b/test/fpm-projects.js
@@ -79,7 +79,7 @@ export const tests = (testCase, uimodulePath) => {
 			)
 		}
 
-		// don't proxy resources/ to CDN unless its needed for flpSandbox.html (via preview-middleware)
+		// don't proxy resources/ to CDN unless its needed for flpSandbox.html (via fiori-tools-preview)
 		if (testCase.platform !== "SAP Build Work Zone, standard edition") {
 			assert.noFileContent(
 				path.join(uimodulePath, "ui5.yaml"),

--- a/test/fpm-projects.js
+++ b/test/fpm-projects.js
@@ -53,12 +53,12 @@ export const tests = (testCase, uimodulePath) => {
 			path.join(uimodulePath, "ui5.yaml"),
 			path.join(uimodulePath, "webapp/manifest.json"),
 			path.join(uimodulePath, "webapp/index.html"),
-			path.join(uimodulePath, "webapp/ext/main/Main.view.xml")
+			path.join(uimodulePath, "webapp/ext/view/Main.view.xml")
 		]
 		if (testCase.enableTypescript) {
-			files.push(path.join(uimodulePath, "webapp/ext/main/Main.controller.ts"))
+			files.push(path.join(uimodulePath, "webapp/ext/view/Main.controller.ts"))
 		} else {
-			files.push(path.join(uimodulePath, "webapp/ext/main/Main.controller.js"))
+			files.push(path.join(uimodulePath, "webapp/ext/view/Main.controller.js"))
 		}
 		assert.file(files)
 	})
@@ -148,10 +148,6 @@ export const tests = (testCase, uimodulePath) => {
 		assert.fileContent(
 			path.join(uimodulePath, "package.json"),
 			"sapux"
-		)
-		assert.fileContent(
-			path.join(uimodulePath, "package.json"),
-			"@sap/ux-specification"
 		)
 	})
 

--- a/test/freestyle-projects.js
+++ b/test/freestyle-projects.js
@@ -90,9 +90,5 @@ export const tests = (testCase, uimodulePath) => {
 				)
 		}
 	})
-
-	it("should use eslint", async function() {
-		assert.file(path.join(uimodulePath, ".eslintrc"))
-	})
 }
 


### PR DESCRIPTION
Generators:
  - Migrate ESLint config: Remove legacy .eslintrc template; delegate ESLint setup to @sap-ux writers via appOptions.eslint: true. Drop manual copy logic from lint.js.
  - Fix sap-ux writer integration: Writers now return their own memfs instance. Commit each writer's FS separately before composing subgenerators, fixing race condition where FPM page
  generator ran before writer finished.
  - Add projectType: "EDMXBackend" to app config.
  - Rename preview-middleware → fiori-tools-preview across templates/config.
  - Bump all deps to exact versions: @sap-ux/*, chalk, yaml, yeoman-*, plus template-level UI5 deps.
  - Fix and update tests: Align test assertions with new generated output shape.
  - Update README to reflect current setup.

Tests:
  - Generate freestyle project — verify eslint.config.mjs present
  - Generate FPM project — verify FPM page subgenerator runs after writer commits, no missing files
  - Run npm test — all suites pass
  - Check no .eslintrc generated (legacy format gone)
  - Verify fiori-tools-preview in generated ui5.yaml (not preview-middleware)